### PR TITLE
Remove migraine tips section and fix index file extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,6 @@
             <li><strong>3)</strong> Check the box ✅ when a set is done. Data saves automatically.</li>
             <li><strong>4)</strong> Tap <em>Print</em> to save a PDF, or <em>Export CSV</em> to download your data.</li>
           </ul>
-          <p class="small muted">Migraine‑friendly tips: keep head/neck relaxed, breathe steady, rest longer if you feel head pressure. Lower the weight instead of pushing harder.</p>
         </div>
         <div class="tip" style="margin-top:8px;">
           <p><strong>Weekly Progress:</strong> If a weight feels easy with smooth form, add 1–2 reps next time or a small weight increase (+2.5–5 lb). If anything hurts or feels “throbby,” rest more or go lighter.</p>


### PR DESCRIPTION
## Summary
- remove the migraine-friendly tip paragraph from the beginner tips card so the text no longer appears in the UI
- rename the root HTML file to index.html so the page serves correctly on Vercel

## Testing
- no tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c8d5a4a720832789f16e68367120ee