### PR TITLE
Add workouts archive page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -307,6 +307,145 @@ tr.done td {
   color: var(--danger);
 }
 
+.workout-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 12px;
+}
+
+.workout-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.workout-header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (min-width: 720px) {
+  .workout-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+.workout-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.workout-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 13px;
+  margin-top: 6px;
+}
+
+.pill-active {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #34d399;
+}
+
+.pill-archived {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #cbd5f5;
+}
+
+.day-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+@media (min-width: 900px) {
+  .day-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.day-card {
+  background: #0f1218;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.day-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.day-header h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.day-meta {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.exercise-summary {
+  border-top: 1px solid #1c2130;
+  padding-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.exercise-summary:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.exercise-summary-title {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-weight: 600;
+}
+
+.exercise-summary-how {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.exercise-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 4px;
+}
+
+.exercise-table th,
+.exercise-table td {
+  font-size: 12px;
+}
+
+.exercise-table td:last-child {
+  text-align: center;
+}
+
+.exercise-summary-footer {
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .sticky-actions {
   position: sticky;
   top: 0;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { DayEntry, WeekResponse } from "@/lib/week";
@@ -381,7 +382,7 @@ export default function HomePage() {
     return (
       <div className="wrap">
         <h1>30-Min Gym Checklist — Beginner (RPE ~6)</h1>
-        <p className="sub">We couldn't load your workouts.</p>
+        <p className="sub">We couldn’t load your workouts.</p>
         {error && <p className="sub dangerc">{error}</p>}
       </div>
     );
@@ -396,12 +397,17 @@ export default function HomePage() {
             3 days/week • “Somewhat hard, still comfortable” • Auto-saves to your account
           </div>
         </div>
-        <div className="legend">
-          <span className="badge">
-            <strong>RPE 6</strong> ≈ 4 reps in reserve
-          </span>
-          <span className="badge">Breathe smooth</span>
-          <span className="badge">No maxing out</span>
+        <div className="topbar">
+          <Link className="btn ghost" href="/workouts">
+            📘 View saved weeks
+          </Link>
+          <div className="legend">
+            <span className="badge">
+              <strong>RPE 6</strong> ≈ 4 reps in reserve
+            </span>
+            <span className="badge">Breathe smooth</span>
+            <span className="badge">No maxing out</span>
+          </div>
         </div>
       </header>
 
@@ -488,7 +494,7 @@ export default function HomePage() {
 
       <div className="grid">
         <div className="card">
-          <h2>Today's Plan</h2>
+          <h2>Today’s Plan</h2>
           {!activeDay ? (
             <p>No day selected.</p>
           ) : (

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -1,0 +1,203 @@
+import Link from "next/link";
+
+import { getDb } from "@/lib/mongodb";
+import { serializeWeek, type DayEntry, type WeekDocument, type WeekResponse } from "@/lib/week";
+
+export const dynamic = "force-dynamic";
+
+type WeekListEntry = WeekResponse & {
+  status: WeekDocument["status"];
+  archivedAt: string | null;
+};
+
+function formatDateTime(iso: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(iso));
+}
+
+function formatWeekOf(weekOf: string) {
+  const date = new Date(`${weekOf}T00:00:00.000Z`);
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeZone: "UTC"
+  }).format(date);
+}
+
+function countDaySets(day: DayEntry) {
+  return day.exercises.reduce(
+    (acc, exercise) => {
+      acc.total += exercise.sets.length;
+      acc.completed += exercise.sets.filter((set) => set.done).length;
+      return acc;
+    },
+    { completed: 0, total: 0 }
+  );
+}
+
+function countWeekSets(week: WeekResponse) {
+  return week.days.reduce(
+    (acc, day) => {
+      const { completed, total } = countDaySets(day);
+      acc.completed += completed;
+      acc.total += total;
+      return acc;
+    },
+    { completed: 0, total: 0 }
+  );
+}
+
+async function fetchWeeks(): Promise<WeekListEntry[]> {
+  const db = await getDb();
+  const collection = db.collection<WeekDocument>("weeks");
+  const documents = await collection
+    .find({}, { sort: { createdAt: -1 } })
+    .limit(24)
+    .toArray();
+
+  return documents.map((doc) => {
+    const serialized = serializeWeek(doc);
+    return {
+      ...serialized,
+      status: doc.status,
+      archivedAt: doc.archivedAt ? doc.archivedAt.toISOString() : null
+    };
+  });
+}
+
+export default async function WorkoutsPage() {
+  let weeks: WeekListEntry[] = [];
+  let loadError: string | null = null;
+
+  try {
+    weeks = await fetchWeeks();
+  } catch (error) {
+    console.error("Failed to load saved workouts", error);
+    loadError = "We couldn’t load your saved workouts. Check your database connection and try again.";
+  }
+
+  return (
+    <div className="wrap">
+      <header>
+        <div>
+          <h1>Saved Workouts</h1>
+          <p className="sub">Review everything currently stored in MongoDB.</p>
+        </div>
+        <div className="topbar">
+          <Link className="btn ghost" href="/">
+            ← Back to tracker
+          </Link>
+        </div>
+      </header>
+
+      {loadError ? (
+        <div className="banner error">
+          <span>{loadError}</span>
+        </div>
+      ) : weeks.length === 0 ? (
+        <div className="card">
+          <h2>No workouts saved yet</h2>
+          <p className="muted">
+            Once you log sets on the tracker, they’ll appear here so you can review or export past weeks.
+          </p>
+        </div>
+      ) : (
+        <div className="workout-list">
+          {weeks.map((week) => {
+            const { completed, total } = countWeekSets(week);
+            const isActive = week.status === "active";
+
+            return (
+              <article className="card workout-card" key={week.id}>
+                <div className="workout-header">
+                  <div>
+                    <h2>Week of {formatWeekOf(week.weekOf)}</h2>
+                    <div className="workout-meta">
+                      <span>
+                        {week.days.length} day{week.days.length === 1 ? "" : "s"}
+                      </span>
+                      <span>
+                        {completed}/{total} sets complete
+                      </span>
+                      <span>Updated {formatDateTime(week.updatedAt)}</span>
+                    </div>
+                  </div>
+                  <div className="workout-tags">
+                    <span className="pill template-pill" title={week.description}>
+                      {week.templateTitle}
+                    </span>
+                    <span className={`pill ${isActive ? "pill-active" : "pill-archived"}`}>
+                      {isActive
+                        ? "Active week"
+                        : week.archivedAt
+                          ? `Archived · ${formatDateTime(week.archivedAt)}`
+                          : "Archived"}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="day-grid">
+                  {week.days.map((day) => {
+                    const { completed: dayCompleted, total: dayTotal } = countDaySets(day);
+
+                    return (
+                      <section className="day-card" key={day.id}>
+                        <div className="day-header">
+                          <h3>{day.name}</h3>
+                          <div className="day-meta">
+                            {day.shortName} • {dayCompleted}/{dayTotal} sets complete
+                          </div>
+                        </div>
+
+                        {day.exercises.map((exercise) => {
+                          const exerciseKey = `${day.id}-${exercise.name}`;
+                          const exerciseCompleted = exercise.sets.filter((set) => set.done).length;
+
+                          return (
+                            <div className="exercise-summary" key={exerciseKey}>
+                              <div className="exercise-summary-title">
+                                <span>{exercise.name}</span>
+                                <span className="muted small">({exercise.target})</span>
+                              </div>
+                              <div className="exercise-summary-how">{exercise.how}</div>
+                              <table className="exercise-table">
+                                <thead>
+                                  <tr>
+                                    <th>Set</th>
+                                    <th>Weight</th>
+                                    <th>{exercise.type === "seconds" ? "Seconds" : "Reps"}</th>
+                                    <th>RPE</th>
+                                    <th>Done</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {exercise.sets.map((set) => (
+                                    <tr key={`${exerciseKey}-${set.set}`}>
+                                      <td>{set.set}</td>
+                                      <td>{set.weight || "—"}</td>
+                                      <td>{set.repsOrSec || "—"}</td>
+                                      <td>{set.rpe || "—"}</td>
+                                      <td>{set.done ? "✅" : "—"}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                              <div className="exercise-summary-footer">
+                                {exerciseCompleted}/{exercise.sets.length} sets complete
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </section>
+                    );
+                  })}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,12 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -35,7 +40,8 @@
     "**/*.js",
     "**/*.jsx",
     "**/*.cjs",
-    "**/*.mjs"
+    "**/*.mjs",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- add a dynamic `/workouts` page that reads MongoDB weeks, totals set progress, and renders each day/exercise in a read-only view
- style the archive with new utility classes and status pills so past weeks are easy to scan
- surface a "View saved weeks" link from the tracker so the new page is discoverable

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ec15a1e48327a87f762caf849e38