### PR TITLE
Fix saved week logged day count

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import type { WithId } from "mongodb";
+
+import { verifyPassword } from "@/lib/auth";
+import {
+  getUsersCollection,
+  normalizeEmail,
+  serializeUser,
+  type UserDocument
+} from "@/lib/users";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { email, password } = body as {
+      email?: string;
+      password?: string;
+    };
+
+    const trimmedEmail = email?.trim() ?? "";
+    const trimmedPassword = password?.trim() ?? "";
+
+    if (!trimmedEmail || !trimmedPassword) {
+      return NextResponse.json(
+        { error: "Email and password are required." },
+        { status: 400 }
+      );
+    }
+
+    const users = await getUsersCollection();
+    const normalizedEmail = normalizeEmail(trimmedEmail);
+    const user = await users.findOne({ email: normalizedEmail });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Invalid email or password." },
+        { status: 401 }
+      );
+    }
+
+    const valid = verifyPassword(trimmedPassword, user.passwordHash);
+
+    if (!valid) {
+      return NextResponse.json(
+        { error: "Invalid email or password." },
+        { status: 401 }
+      );
+    }
+
+    const now = new Date();
+    await users.updateOne(
+      { _id: user._id },
+      { $set: { lastLoginAt: now, updatedAt: now } }
+    );
+
+    const updated: WithId<UserDocument> = { ...user, lastLoginAt: now, updatedAt: now };
+
+    return NextResponse.json({ user: serializeUser(updated) });
+  } catch (error) {
+    console.error("Failed to log in user", error);
+    return NextResponse.json({ error: "Failed to log in user." }, { status: 500 });
+  }
+}

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import type { WithId } from "mongodb";
+
+import { hashPassword } from "@/lib/auth";
+import {
+  getUsersCollection,
+  normalizeEmail,
+  serializeUser,
+  type UserDocument
+} from "@/lib/users";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, email, password } = body as {
+      name?: string;
+      email?: string;
+      password?: string;
+    };
+
+    const trimmedName = name?.trim() ?? "";
+    const trimmedEmail = email?.trim() ?? "";
+    const trimmedPassword = password?.trim() ?? "";
+
+    if (!trimmedName || !trimmedEmail || !trimmedPassword) {
+      return NextResponse.json(
+        { error: "Name, email, and password are required." },
+        { status: 400 }
+      );
+    }
+
+    if (trimmedPassword.length < 8) {
+      return NextResponse.json(
+        { error: "Choose a password with at least 8 characters." },
+        { status: 400 }
+      );
+    }
+
+    const emailKey = normalizeEmail(trimmedEmail);
+    const users = await getUsersCollection();
+    const existing = await users.findOne({ email: emailKey });
+
+    if (existing) {
+      return NextResponse.json(
+        { error: "An account with that email already exists." },
+        { status: 409 }
+      );
+    }
+
+    const passwordHash = hashPassword(trimmedPassword);
+    const now = new Date();
+
+    const doc: UserDocument = {
+      name: trimmedName,
+      email: emailKey,
+      passwordHash,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    const insertResult = await users.insertOne(doc);
+    const inserted: WithId<UserDocument> = { ...doc, _id: insertResult.insertedId };
+
+    return NextResponse.json({ user: serializeUser(inserted) }, { status: 201 });
+  } catch (error) {
+    console.error("Failed to register user", error);
+    return NextResponse.json({ error: "Failed to register user." }, { status: 500 });
+  }
+}

--- a/app/api/week/new/route.ts
+++ b/app/api/week/new/route.ts
@@ -1,36 +1,84 @@
 import { NextResponse } from "next/server";
-import { ObjectId } from "mongodb";
+import { ObjectId, type Filter } from "mongodb";
 
 import { getDb } from "@/lib/mongodb";
+import { WEEK_TEMPLATES } from "@/lib/templates";
 import {
   createWeekDocument,
   serializeWeek,
   type WeekDocument,
-  nextTemplateIndex
+  nextTemplateIndex,
+  getWeekStart
 } from "@/lib/week";
 
 export const dynamic = "force-dynamic";
 
+function parseUserId(
+  value: string | null | undefined
+): { userId: ObjectId | null } | { error: string } {
+  if (value === null || value === undefined) {
+    return { userId: null };
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+    return { userId: null };
+  }
+
+  if (!ObjectId.isValid(trimmed)) {
+    return { error: "Invalid user" };
+  }
+
+  return { userId: new ObjectId(trimmed) };
+}
+
+function buildUserFilter(userId: ObjectId | null): Filter<WeekDocument> {
+  if (userId) {
+    return { userId };
+  }
+
+  return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { id, days } = body as { id?: string; days?: WeekDocument["days"] };
+    const { id, days, templateIndex, userId: rawUserId } = body as {
+      id?: string;
+      days?: WeekDocument["days"];
+      templateIndex?: number;
+      userId?: string | null;
+    };
 
     if (!id || !Array.isArray(days)) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
+    const parsed = parseUserId(rawUserId ?? null);
+
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    const { userId } = parsed;
+
     const db = await getDb();
     const collection = db.collection<WeekDocument>("weeks");
     const objectId = new ObjectId(id);
-    const existing = await collection.findOne({ _id: objectId, status: "active" });
+    const filter: Filter<WeekDocument> = {
+      _id: objectId,
+      status: "active",
+      ...buildUserFilter(userId)
+    };
+    const existing = await collection.findOne(filter);
 
     if (!existing) {
       return NextResponse.json({ error: "Week not found" }, { status: 404 });
     }
 
     await collection.updateOne(
-      { _id: objectId },
+      filter,
       {
         $set: {
           days,
@@ -41,8 +89,23 @@ export async function POST(request: Request) {
       }
     );
 
-    const newTemplateIndex = nextTemplateIndex(existing.templateIndex);
-    const fresh = createWeekDocument(newTemplateIndex);
+    let newTemplateIndex: number;
+
+    if (typeof templateIndex === "number") {
+      if (
+        !Number.isInteger(templateIndex) ||
+        templateIndex < 0 ||
+        templateIndex >= WEEK_TEMPLATES.length
+      ) {
+        return NextResponse.json({ error: "Invalid template" }, { status: 400 });
+      }
+      newTemplateIndex = templateIndex;
+    } else {
+      newTemplateIndex = nextTemplateIndex(existing.templateIndex);
+    }
+
+    const currentWeekOf = getWeekStart();
+    const fresh = createWeekDocument(newTemplateIndex, currentWeekOf, userId);
     const insertResult = await collection.insertOne(fresh);
     const inserted = { ...fresh, _id: insertResult.insertedId };
 

--- a/app/api/week/route.ts
+++ b/app/api/week/route.ts
@@ -1,22 +1,63 @@
 import { NextResponse } from "next/server";
-import { ObjectId } from "mongodb";
+import { ObjectId, type Filter } from "mongodb";
 
 import { getDb } from "@/lib/mongodb";
 import { createWeekDocument, serializeWeek, type WeekDocument } from "@/lib/week";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+function parseUserId(
+  value: string | null | undefined
+): { userId: ObjectId | null } | { error: string } {
+  if (value === null || value === undefined) {
+    return { userId: null };
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+    return { userId: null };
+  }
+
+  if (!ObjectId.isValid(trimmed)) {
+    return { error: "Invalid user" };
+  }
+
+  return { userId: new ObjectId(trimmed) };
+}
+
+function buildUserFilter(userId: ObjectId | null): Filter<WeekDocument> {
+  if (userId) {
+    return { userId };
+  }
+
+  return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+}
+
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const parsed = parseUserId(searchParams.get("userId"));
+
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    const { userId } = parsed;
+
     const db = await getDb();
     const collection = db.collection<WeekDocument>("weeks");
-    const active = await collection.findOne({ status: "active" }, { sort: { createdAt: -1 } });
+    const filter: Filter<WeekDocument> = {
+      status: "active",
+      ...buildUserFilter(userId)
+    };
+    const active = await collection.findOne(filter, { sort: { createdAt: -1 } });
 
     if (active) {
       return NextResponse.json({ week: serializeWeek(active) });
     }
 
-    const fresh = createWeekDocument(0);
+    const fresh = createWeekDocument(0, undefined, userId);
     const insertResult = await collection.insertOne(fresh);
     const inserted = { ...fresh, _id: insertResult.insertedId };
     return NextResponse.json({ week: serializeWeek(inserted) });
@@ -29,20 +70,34 @@ export async function GET() {
 export async function PUT(request: Request) {
   try {
     const body = await request.json();
-    const { id, days } = body as { id?: string; days?: WeekDocument["days"] };
+    const { id, days, userId: rawUserId } = body as {
+      id?: string;
+      days?: WeekDocument["days"];
+      userId?: string | null;
+    };
 
     if (!id || !Array.isArray(days)) {
       return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
     }
 
+    const parsed = parseUserId(rawUserId ?? null);
+
+    if ("error" in parsed) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    const { userId } = parsed;
+
     const db = await getDb();
     const collection = db.collection<WeekDocument>("weeks");
     const objectId = new ObjectId(id);
+    const filter: Filter<WeekDocument> = {
+      _id: objectId,
+      status: "active",
+      ...buildUserFilter(userId)
+    };
 
-    const result = await collection.updateOne(
-      { _id: objectId, status: "active" },
-      { $set: { days, updatedAt: new Date() } }
-    );
+    const result = await collection.updateOne(filter, { $set: { days, updatedAt: new Date() } });
 
     if (result.matchedCount === 0) {
       return NextResponse.json({ error: "Week not found" }, { status: 404 });

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type AuthMode = "login" | "register";
+
+type StoredUser = {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string | null;
+};
+
+const USER_STORAGE_KEY = "fitmotion_user";
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) {
+    return "—";
+  }
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short"
+    }).format(new Date(value));
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return value;
+  }
+}
+
+export default function AuthPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<AuthMode>("login");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [user, setUser] = useState<StoredUser | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(USER_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as StoredUser;
+        setUser(parsed);
+        setName(parsed.name);
+        setEmail(parsed.email);
+      }
+    } catch (storageError) {
+      console.error("Failed to load stored user", storageError);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key !== USER_STORAGE_KEY) {
+        return;
+      }
+
+      if (!event.newValue) {
+        setUser(null);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(event.newValue) as StoredUser;
+        setUser(parsed);
+        setName(parsed.name);
+        setEmail(parsed.email);
+      } catch (storageError) {
+        console.error("Failed to parse stored user", storageError);
+        setUser(null);
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (user) {
+      window.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user));
+    } else {
+      window.localStorage.removeItem(USER_STORAGE_KEY);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    setError(null);
+    setMessage(null);
+  }, [mode]);
+
+  const title = mode === "register" ? "Create your Fitmotion account" : "Log in to Fitmotion";
+  const subtitle =
+    mode === "register"
+      ? "Sign up once to keep your workout history synced across devices."
+      : "Log back in to pick up right where you left off.";
+
+  const submitLabel = loading
+    ? "One moment…"
+    : mode === "register"
+    ? "Create account"
+    : "Log in";
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    const trimmedPassword = password.trim();
+
+    if (!trimmedEmail || !trimmedPassword || (mode === "register" && !trimmedName)) {
+      setError("Please fill in all required fields.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/auth/${mode}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          mode === "register"
+            ? { name: trimmedName, email: trimmedEmail, password: trimmedPassword }
+            : { email: trimmedEmail, password: trimmedPassword }
+        )
+      });
+
+      const result = (await response.json()) as { user?: StoredUser; error?: string };
+
+      if (!response.ok) {
+        setError(result.error ?? "We couldn’t complete that request.");
+        return;
+      }
+
+      if (result.user) {
+        setUser(result.user);
+        setName(result.user.name);
+        setEmail(result.user.email);
+        setMessage(mode === "register" ? "Account created! You’re signed in." : "Welcome back!");
+        setPassword("");
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(result.user));
+        }
+        router.push("/");
+        return;
+      }
+    } catch (submitError) {
+      console.error(`Failed to ${mode}`, submitError);
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const lastSynced = useMemo(() => formatDateTime(user?.updatedAt), [user?.updatedAt]);
+  const lastLogin = useMemo(() => formatDateTime(user?.lastLoginAt ?? user?.updatedAt), [
+    user?.lastLoginAt,
+    user?.updatedAt
+  ]);
+
+  function handleSignOut() {
+    setUser(null);
+    setMessage("You’re signed out.");
+    setPassword("");
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="wrap auth-wrap">
+        <header className="auth-header">
+          <Link className="auth-logo" href="/">
+            <span className="sr-only">Return home</span>
+            <Image
+              alt="Fitmotion"
+              className="auth-logo__image"
+              height={120}
+              priority
+              src="/fitmotion-logo.svg"
+              width={120}
+            />
+          </Link>
+          <h1>{title}</h1>
+          <p className="auth-subtitle">{subtitle}</p>
+          <div className="auth-toggle">
+            <button
+              className={mode === "login" ? "active" : undefined}
+              onClick={() => setMode("login")}
+              type="button"
+              disabled={loading}
+            >
+              Log in
+            </button>
+            <button
+              className={mode === "register" ? "active" : undefined}
+              onClick={() => setMode("register")}
+              type="button"
+              disabled={loading}
+            >
+              Register
+            </button>
+          </div>
+        </header>
+
+        <div className="auth-grid">
+          <div className="card auth-card">
+            <form className="auth-form" onSubmit={handleSubmit}>
+              {error && (
+                <div className="banner error auth-banner">
+                  <span>{error}</span>
+                </div>
+              )}
+              {message && (
+                <div className="banner success auth-banner">
+                  <span>{message}</span>
+                </div>
+              )}
+
+              {mode === "register" && (
+                <label className="auth-field" htmlFor="auth-name">
+                  <span>Name</span>
+                  <input
+                    autoComplete="name"
+                    className="in"
+                    id="auth-name"
+                    onChange={(event) => setName(event.target.value)}
+                    placeholder="Your name"
+                    type="text"
+                    value={name}
+                    disabled={loading}
+                  />
+                </label>
+              )}
+
+              <label className="auth-field" htmlFor="auth-email">
+                <span>Email</span>
+                <input
+                  autoComplete="email"
+                  className="in"
+                  id="auth-email"
+                  onChange={(event) => setEmail(event.target.value)}
+                  placeholder="you@example.com"
+                  type="email"
+                  value={email}
+                  disabled={loading}
+                />
+              </label>
+
+              <label className="auth-field" htmlFor="auth-password">
+                <span>Password</span>
+                <input
+                  autoComplete={mode === "register" ? "new-password" : "current-password"}
+                  className="in"
+                  id="auth-password"
+                  minLength={8}
+                  onChange={(event) => setPassword(event.target.value)}
+                  placeholder="••••••••"
+                  type="password"
+                  value={password}
+                  disabled={loading}
+                />
+              </label>
+
+              <button className="btn primary" disabled={loading} type="submit">
+                {submitLabel}
+              </button>
+            </form>
+          </div>
+
+          {user ? (
+            <aside className="card auth-profile">
+              <h2>Your saved profile</h2>
+              <dl className="auth-profile__list">
+                <div>
+                  <dt>Name</dt>
+                  <dd>{user.name}</dd>
+                </div>
+                <div>
+                  <dt>Email</dt>
+                  <dd>{user.email}</dd>
+                </div>
+                <div>
+                  <dt>Last login</dt>
+                  <dd>{lastLogin}</dd>
+                </div>
+                <div>
+                  <dt>Last synced</dt>
+                  <dd>{lastSynced}</dd>
+                </div>
+              </dl>
+              <div className="auth-profile__actions">
+                <button className="btn ghost" onClick={handleSignOut} type="button">
+                  Sign out
+                </button>
+                <Link className="btn ghost" href="/">
+                  Back to tracker
+                </Link>
+              </div>
+            </aside>
+          ) : (
+            <aside className="card auth-profile auth-profile--empty">
+              <h2>Why create an account?</h2>
+              <ul>
+                <li>Back up your workouts and reload them on any device.</li>
+                <li>Keep your active week synced with your saved archive.</li>
+                <li>Fast login means you’re logging sets in seconds.</li>
+              </ul>
+              <Link className="btn ghost" href="/">
+                Preview the tracker
+              </Link>
+            </aside>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,30 +1,93 @@
 :root {
-  --bg: #0b0c10;
-  --panel: #111217;
-  --muted: #9aa1aa;
-  --text: #eef1f4;
-  --accent: #6ee7b7;
-  --accent2: #60a5fa;
-  --border: #23252d;
-  --danger: #ef4444;
-  --warn: #f59e0b;
+  --bg: #02060b;
+  --bg-secondary: #07121f;
+  --surface: rgba(9, 17, 28, 0.92);
+  --surface-alt: rgba(11, 23, 36, 0.9);
+  --panel: rgba(8, 16, 27, 0.88);
+  --text: #c6d7e6;
+  --text-strong: #f6fbff;
+  --muted: #93aec4;
+  --muted-bright: #b4cde2;
+  --accent: #18d6c6;
+  --accent-strong: #0fb3a4;
+  --accent-soft: rgba(24, 214, 198, 0.18);
+  --accent-glow: rgba(24, 214, 198, 0.38);
+  --border: rgba(39, 64, 84, 0.65);
+  --border-strong: rgba(50, 84, 105, 0.85);
+  --danger: #fb7185;
+  --warn: #facc15;
+  --success: #34d399;
+  --shadow: 0 22px 44px rgba(5, 12, 21, 0.55);
+  --shadow-soft: 0 18px 32px rgba(12, 28, 43, 0.35);
 }
 
 * {
   box-sizing: border-box;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html,
 body {
   margin: 0;
   padding: 0;
-  background: var(--bg);
+  min-height: 100%;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(24, 214, 198, 0.18), transparent 54%),
+    radial-gradient(circle at 82% 0%, rgba(11, 139, 208, 0.22), transparent 60%),
+    var(--bg);
   color: var(--text);
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Inter", "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+.archive-page {
+  --bg: #02060b;
+  --bg-secondary: #07121f;
+  --surface: rgba(9, 17, 28, 0.92);
+  --surface-alt: rgba(11, 23, 36, 0.9);
+  --panel: rgba(8, 16, 27, 0.88);
+  --text: #c6d7e6;
+  --text-strong: #f6fbff;
+  --muted: #93aec4;
+  --muted-bright: #b4cde2;
+  --accent: #18d6c6;
+  --accent-strong: #0fb3a4;
+  --accent-soft: rgba(24, 214, 198, 0.18);
+  --accent-glow: rgba(24, 214, 198, 0.38);
+  --border: rgba(39, 64, 84, 0.65);
+  --border-strong: rgba(50, 84, 105, 0.85);
+  --danger: #fb7185;
+  --warn: #facc15;
+  --success: #34d399;
+  --shadow: 0 22px 44px rgba(5, 12, 21, 0.55);
+  --shadow-soft: 0 18px 32px rgba(12, 28, 43, 0.35);
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(24, 214, 198, 0.16), transparent 58%),
+    radial-gradient(circle at 86% 4%, rgba(11, 139, 208, 0.18), transparent 62%),
+    var(--bg);
+  padding: clamp(30px, 6vw, 72px) 0;
+}
+
+.archive-wrap {
+  color: var(--text);
 }
 
 a {
-  color: var(--accent2);
+  color: var(--accent);
   text-decoration: none;
 }
 
@@ -32,251 +95,668 @@ a:hover {
   text-decoration: underline;
 }
 
-.wrap {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-header {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  margin-bottom: 14px;
-}
-
-h1 {
-  font-size: 20px;
+p,
+ul {
   margin: 0;
-  letter-spacing: 0.2px;
 }
 
-.sub {
-  color: var(--muted);
-  font-size: 13px;
+ul {
+  padding-left: 18px;
 }
 
-.topbar {
+.wrap {
+  width: min(100%, 1120px);
+  margin: 0 auto;
+  padding: clamp(20px, 4vw, 44px) clamp(16px, 4vw, 48px) 80px;
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 28px);
 }
 
-.pill {
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(20px, 4vw, 36px);
+  border-radius: 30px;
   border: 1px solid var(--border);
-  padding: 8px 10px;
-  border-radius: 999px;
-  background: #0f1116;
-  color: var(--text);
-  cursor: pointer;
-  font-size: 13px;
+  background: linear-gradient(140deg, rgba(7, 16, 26, 0.95), rgba(7, 20, 31, 0.82));
+  box-shadow: var(--shadow);
+  overflow: hidden;
 }
 
-.pill.active {
-  background: linear-gradient(90deg, rgba(110, 231, 183, 0.12), rgba(96, 165, 250, 0.12));
-  border-color: #2a2f3a;
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -120px -160px auto auto;
+  width: 360px;
+  height: 360px;
+  background: radial-gradient(circle, rgba(24, 214, 198, 0.32), transparent 60%);
+  filter: blur(0.8px);
+  opacity: 0.75;
+  transform: rotate(12deg);
+  pointer-events: none;
+  animation: drift 22s ease-in-out infinite;
 }
 
-.btn {
-  border: 1px solid var(--border);
-  background: #141823;
-  color: var(--text);
-  padding: 8px 12px;
-  border-radius: 10px;
-  cursor: pointer;
-  font-size: 13px;
-  transition: border-color 0.2s ease;
+.archive-page .hero {
+  background: linear-gradient(140deg, rgba(6, 16, 26, 0.92), rgba(8, 22, 34, 0.82));
+  border: 1px solid rgba(32, 68, 92, 0.55);
+  box-shadow: var(--shadow);
 }
 
-.btn:hover {
-  border-color: #2a2f3a;
+.archive-page .hero::before {
+  background: radial-gradient(circle, rgba(24, 214, 198, 0.22), transparent 62%);
+  filter: blur(1.2px);
+  opacity: 0.65;
 }
 
-.btn.warn {
-  background: rgba(245, 158, 11, 0.12);
-  border-color: rgba(245, 158, 11, 0.35);
+.hero * {
+  position: relative;
+  z-index: 1;
 }
 
-.btn.danger {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.35);
+.hero.home-hero {
+  gap: clamp(16px, 4vw, 28px);
+  padding: clamp(18px, 6vw, 32px);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(6, 16, 26, 0.92), rgba(8, 22, 34, 0.82));
+  border: 1px solid rgba(32, 68, 92, 0.55);
 }
 
-.grid {
+.hero.home-hero::before {
+  inset: -140px -100px auto auto;
+  width: 260px;
+  height: 260px;
+  opacity: 0.45;
+}
+
+.home-hero__layout {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 12px;
+  gap: clamp(14px, 4vw, 24px);
+  grid-template-areas:
+    "brand"
+    "level"
+    "summary"
+    "actions";
 }
 
-@media (min-width: 900px) {
-  .grid {
-    grid-template-columns: 1fr 1fr;
+.home-hero__layout--simple {
+  grid-template-areas:
+    "brand"
+    "summary"
+    "actions";
+}
+
+.home-hero__actions {
+  grid-area: actions;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  align-items: stretch;
+}
+
+@media (min-width: 640px) {
+  .home-hero__layout {
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+    grid-template-areas:
+      "brand level"
+      "summary actions";
+    align-items: start;
+  }
+
+  .home-hero__layout--simple {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "brand"
+      "summary"
+      "actions";
+  }
+
+  .home-hero__actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    width: auto;
+    justify-self: end;
+    align-self: start;
   }
 }
 
-.card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 14px;
+@media (max-width: 520px) {
+  .home-hero__brand {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .home-hero__title {
+    align-items: center;
+  }
 }
 
-.card h2 {
-  font-size: 16px;
-  margin: 0 0 8px;
-}
-
-.muted {
-  color: var(--muted);
-}
-
-.tip {
-  background: #12161f;
-  border: 1px dashed #273043;
-  padding: 10px;
-  border-radius: 10px;
-  font-size: 13px;
-}
-
-.banner {
-  display: flex;
+.home-hero__brand {
+  grid-area: brand;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: clamp(12px, 4vw, 20px);
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  border: 1px solid rgba(38, 148, 228, 0.35);
-  background: rgba(37, 99, 235, 0.08);
-  padding: 10px 12px;
-  border-radius: 10px;
+  width: 100%;
+  min-width: 0;
+}
+
+.home-hero__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(10px, 2.2vw, 14px);
+  border-radius: 20px;
+  background: rgba(24, 214, 198, 0.14);
+  box-shadow: 0 18px 36px rgba(24, 214, 198, 0.22);
+}
+
+.home-hero__logo-image {
+  width: clamp(58px, 14vw, 86px);
+  height: auto;
+  animation: logoPulse 6s ease-in-out infinite;
+  filter: drop-shadow(0 0 24px rgba(24, 214, 198, 0.42));
+}
+
+.home-hero__title {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.home-hero__welcome {
+  margin: 0;
+  color: var(--muted);
   font-size: 13px;
-  margin-bottom: 10px;
 }
 
-.banner.error {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.4);
+.home-hero__brand h1 {
+  margin: 0;
 }
 
-.banner.success {
-  background: rgba(16, 185, 129, 0.12);
-  border-color: rgba(16, 185, 129, 0.4);
+.home-hero__brand .eyebrow {
+  letter-spacing: 0.28em;
+}
+
+.home-hero__level {
+  grid-area: level;
+  width: 100%;
+  align-self: start;
+}
+
+.home-hero__field {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .home-hero__level {
+    justify-self: end;
+  }
+
+  .home-hero__field {
+    min-width: 220px;
+    max-width: 280px;
+  }
+}
+
+.home-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.home-field .in {
+  width: 100%;
+}
+
+.home-hero__plan-summary {
+  grid-area: summary;
+  display: grid;
+  gap: 6px;
+  padding: 16px 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(24, 214, 198, 0.24);
+  background: linear-gradient(140deg, rgba(6, 16, 26, 0.82), rgba(8, 22, 34, 0.72));
+  box-shadow: inset 0 0 0 1px rgba(24, 214, 198, 0.08);
+}
+
+.home-hero__plan-summary--empty {
+  gap: 8px;
+}
+
+@media (min-width: 640px) {
+  .home-hero__plan-summary {
+    padding: 18px 22px;
+  }
+}
+
+.home-hero__plan-label {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: var(--muted-bright);
+}
+
+.home-hero__plan-title {
+  margin: 0;
+  font-size: clamp(17px, 4vw, 20px);
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.home-hero__plan-summary .home-hero__description {
+  margin-top: 4px;
+  font-size: 13px;
+  max-width: none;
+}
+
+.home-hero__select {
+  background-color: rgba(8, 20, 32, 0.78);
+  border: 1px solid rgba(44, 78, 100, 0.7);
+  border-radius: 18px;
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 16px;
+  min-height: 46px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.home-hero__description {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 60ch;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media (min-width: 768px) {
+  .home-hero__description {
+    max-width: 72ch;
+  }
+}
+
+.home-hero__link {
+  width: 100%;
+  justify-content: center;
+  align-self: stretch;
+  gap: 6px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  line-height: 1.2;
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.home-hero__link svg {
+  width: 16px;
+  height: 16px;
+  opacity: 0.75;
+  transition: transform 0.2s ease;
+}
+
+.home-hero__link:hover svg {
+  transform: translateX(2px);
+}
+
+@media (min-width: 640px) {
+  .home-hero__link {
+    width: auto;
+    align-self: center;
+    justify-content: flex-start;
+    padding: 8px 18px;
+  }
+}
+
+.home-hero__select:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(24, 214, 198, 0.18);
+  border-color: rgba(24, 214, 198, 0.65);
+}
+
+@media (min-width: 640px) {
+  .home-field .in {
+    max-width: none;
+  }
+}
+
+.hero-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 11px;
+  color: var(--muted-bright);
+  margin: 0;
+}
+
+.hero h1 {
+  font-size: clamp(26px, 5vw, 40px);
+  line-height: 1.15;
+  margin: 0;
+  color: var(--text-strong);
+}
+
+.hero-sub {
+  font-size: clamp(14px, 3.4vw, 16px);
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hero-actions > * {
+  width: fit-content;
+}
+
+.hero-actions .legend {
+  justify-content: flex-start;
+}
+
+.hero-compact {
+  padding: clamp(20px, 3vw, 30px);
+}
+
+.archive-hero {
+  gap: 20px;
+}
+
+.archive-hero__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.archive-hero__heading .hero-sub {
+  max-width: 58ch;
+}
+
+.archive-page .archive-hero {
+  background: linear-gradient(150deg, rgba(6, 18, 28, 0.95), rgba(9, 28, 40, 0.85));
+  border: 1px solid rgba(32, 68, 92, 0.55);
+}
+
+@media (min-width: 880px) {
+  .hero {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 32px;
+  }
+
+  .hero-heading {
+    flex: 2 1 auto;
+  }
+
+  .hero-actions {
+    flex: 1 1 auto;
+    align-items: flex-end;
+  }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 20, 32, 0.82);
+  color: var(--text-strong);
+  padding: 10px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  box-shadow: 0 16px 28px rgba(5, 12, 20, 0.35);
+  white-space: nowrap;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 20px 36px rgba(5, 12, 20, 0.38);
+  background: rgba(12, 26, 40, 0.88);
+}
+
+.btn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn.primary {
+  border: none;
+  background: linear-gradient(120deg, #24f1d6, #18bff5);
+  color: #032024;
+  box-shadow: 0 22px 34px rgba(30, 204, 220, 0.4);
+}
+
+.btn.primary:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 26px 44px rgba(30, 204, 220, 0.46);
 }
 
 .btn.ghost {
   background: transparent;
-  border-color: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow: none;
 }
 
 .btn.ghost:hover {
-  border-color: rgba(255, 255, 255, 0.25);
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.04);
 }
 
-.confirm-banner {
-  background: rgba(245, 158, 11, 0.12);
-  border: 1px solid rgba(245, 158, 11, 0.4);
-  border-radius: 12px;
-  padding: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-bottom: 14px;
-  font-size: 13px;
+.btn.warn {
+  background: rgba(250, 204, 21, 0.14);
+  border-color: rgba(250, 204, 21, 0.4);
+  color: #fdf5c4;
 }
 
-.confirm-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+.btn.danger {
+  background: rgba(251, 113, 133, 0.12);
+  border-color: rgba(251, 113, 133, 0.45);
+  color: #ffe4e8;
 }
 
-.exercise {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 10px;
-  margin-bottom: 10px;
-  background: #0f1218;
-}
-
-.exercise header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.exercise h3 {
-  font-size: 15px;
-  margin: 0;
-}
-
-.exercise .how {
-  font-size: 12px;
-  color: var(--muted);
-  margin-top: 6px;
-}
-
-.sets {
-  margin-top: 8px;
-  overflow-x: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th,
-td {
-  border-bottom: 1px solid #1c2130;
-  padding: 6px;
-  font-size: 13px;
-  text-align: left;
-}
-
-th {
-  color: #b7bec8;
+.btn-label {
   font-weight: 600;
 }
 
-td .in {
-  width: 100%;
-  background: #0b0f18;
-  border: 1px solid #22293a;
-  border-radius: 8px;
-  color: var(--text);
-  padding: 6px 8px;
-}
-
-select.in {
-  appearance: none;
-}
-
-td .chk {
-  width: 18px;
-  height: 18px;
-}
-
-tr.done td {
-  background: rgba(110, 231, 183, 0.06);
-}
-
-.small {
-  font-size: 12px;
-}
-
-.footer {
+.topbar {
   display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border-radius: 24px;
+  padding: 16px;
+  background: rgba(8, 17, 29, 0.88);
+  border: 1px solid rgba(24, 214, 198, 0.24);
+  box-shadow: 0 18px 36px rgba(8, 20, 32, 0.38);
+  backdrop-filter: blur(18px);
+}
+
+@media (min-width: 960px) {
+  .topbar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.topbar__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (min-width: 960px) {
+  .topbar__primary {
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+  }
+}
+
+.topbar__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-bright);
+}
+
+@media (min-width: 960px) {
+  .topbar__title {
+    display: none;
+  }
+}
+
+.tab-scroll {
+  margin: 0 -4px;
+  padding-bottom: 4px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.tab-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.tab-scroll .tab-group {
+  flex-wrap: nowrap;
+  min-width: max-content;
+}
+
+@media (min-width: 960px) {
+  .tab-scroll {
+    margin: 0;
+    padding-bottom: 0;
+    overflow: visible;
+  }
+
+  .tab-scroll .tab-group {
+    flex-wrap: wrap;
+  }
+}
+
+.topbar__secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+@media (min-width: 600px) {
+  .topbar__secondary {
+    flex-direction: row;
+    align-items: center;
+    gap: 14px;
+  }
+}
+
+.topbar__actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  width: 100%;
+}
+
+.topbar__actions .btn {
+  width: 100%;
+  padding: 10px 0;
+  font-size: 13px;
+}
+
+@media (min-width: 600px) {
+  .topbar__actions {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    gap: 10px;
+    width: auto;
+  }
+
+  .topbar__actions .btn {
+    width: auto;
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+}
+
+.sticky-actions {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 18px 0 10px;
+  background: linear-gradient(180deg, rgba(2, 6, 11, 0.02) 0%, rgba(2, 6, 11, 0.78) 50%, transparent 100%);
+  backdrop-filter: blur(22px);
+}
+
+.tab-group {
+  display: flex;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 12px;
 }
 
-.spacer {
-  flex: 1 1 auto;
+.pill {
+  border: 1px solid rgba(47, 99, 118, 0.6);
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(13, 27, 37, 0.82);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pill.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(24, 214, 198, 0.25);
+}
+
+button.pill {
+  cursor: pointer;
+  background: rgba(10, 20, 32, 0.78);
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+button.pill:hover {
+  background: rgba(24, 214, 198, 0.16);
+  border-color: rgba(24, 214, 198, 0.6);
 }
 
 .legend {
@@ -289,39 +769,16 @@ tr.done td {
 }
 
 .badge {
-  padding: 2px 6px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  background: #0e1320;
-}
-
-.success {
-  color: #22c55e;
-}
-
-.warnc {
-  color: var(--warn);
-}
-
-.dangerc {
-  color: var(--danger);
-}
-
-.sticky-actions {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: linear-gradient(to bottom, rgba(11, 12, 16, 0.95), rgba(11, 12, 16, 0.75) 85%, transparent);
-  padding: 8px 0 6px;
-  backdrop-filter: blur(2px);
-}
-
-.hidden {
-  display: none;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 24, 34, 0.72);
+  box-shadow: 0 6px 12px rgba(5, 10, 16, 0.35);
 }
 
 .status-indicator {
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 600;
   color: var(--muted);
 }
 
@@ -334,37 +791,2109 @@ tr.done td {
 }
 
 .status-indicator.saved {
+  color: var(--success);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+@media (min-width: 980px) {
+  .grid {
+    grid-template-columns: 3fr 2fr;
+  }
+}
+
+.card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 26px;
+  padding: clamp(16px, 3vw, 26px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-soft);
+}
+
+.card h2 {
+  margin: 0;
+  font-size: clamp(18px, 3.2vw, 22px);
+  color: var(--text-strong);
+}
+
+.card-title--desktop {
+  display: none;
+}
+
+@media (min-width: 960px) {
+  .card-title--desktop {
+    display: block;
+  }
+}
+
+.guide-card {
+  gap: 12px;
+}
+
+.guide-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.sub {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.small {
+  font-size: 12px;
+}
+
+.tip {
+  background: rgba(8, 17, 28, 0.72);
+  border: 1px dashed rgba(35, 88, 110, 0.7);
+  padding: 12px;
+  border-radius: 18px;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  border: 1px solid rgba(30, 156, 204, 0.45);
+  background: rgba(9, 45, 68, 0.45);
+  padding: 12px 14px;
+  border-radius: 18px;
+  font-size: 13px;
+  box-shadow: var(--shadow-soft);
+}
+
+.banner.error {
+  background: rgba(251, 113, 133, 0.14);
+  border-color: rgba(251, 113, 133, 0.45);
+}
+
+.banner.success {
+  background: rgba(37, 211, 156, 0.16);
+  border-color: rgba(37, 211, 156, 0.45);
+}
+
+.confirm-banner {
+  background: rgba(250, 204, 21, 0.14);
+  border: 1px solid rgba(250, 204, 21, 0.45);
+  border-radius: 20px;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.exercise {
+  border: 1px solid rgba(44, 78, 100, 0.55);
+  border-radius: 22px;
+  padding: 14px;
+  margin-bottom: 14px;
+  background: rgba(10, 22, 32, 0.78);
+  box-shadow: 0 12px 26px rgba(8, 20, 30, 0.35);
+}
+
+.exercise header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.exercise__title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.exercise__suggested {
+  margin: 0;
+  color: var(--muted);
+}
+
+.exercise h3 {
+  font-size: 16px;
+  margin: 0;
+  color: var(--text-strong);
+}
+
+.exercise details.how {
+  margin-top: 10px;
+  border: 1px solid rgba(44, 78, 100, 0.6);
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: rgba(6, 14, 24, 0.72);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.exercise details.how summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-bright);
+  list-style: none;
+}
+
+.exercise details.how summary:focus {
+  outline: none;
+}
+
+.exercise details.how summary::-webkit-details-marker {
+  display: none;
+}
+
+.exercise details.how[open] {
+  border-color: rgba(24, 214, 198, 0.4);
+  box-shadow: 0 0 0 1px rgba(24, 214, 198, 0.15);
+}
+
+.exercise details.how[open] summary {
   color: var(--accent);
 }
 
-.tab-group {
-  display: flex;
+.exercise details.how p {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.sets {
+  margin-top: 10px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 440px;
+}
+
+.tracker-table {
+  min-width: 440px;
+}
+
+th,
+td {
+  border-bottom: 1px solid rgba(37, 64, 84, 0.7);
+  padding: 8px 10px;
+  font-size: 13px;
+  text-align: left;
+}
+
+th {
+  color: var(--muted-bright);
+  font-weight: 600;
+}
+
+td .in {
+  width: 100%;
+  background: rgba(8, 18, 30, 0.82);
+  border: 1px solid rgba(44, 78, 100, 0.7);
+  border-radius: 12px;
+  color: var(--text-strong);
+  padding: 8px 10px;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+select.in {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(1em + 2px), calc(100% - 13px) calc(1em + 2px);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 32px;
+}
+
+.card select:focus,
+.card input:focus,
+.card textarea:focus,
+.card button:focus,
+td .in:focus,
+button:focus,
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(24, 214, 198, 0.18);
+  border-color: rgba(24, 214, 198, 0.65);
+}
+
+td .in:focus {
+  box-shadow: 0 0 0 4px rgba(24, 214, 198, 0.18);
+}
+
+.set-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.set-cell__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(24, 214, 198, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.set-cell__done {
+  display: inline-flex;
+  align-items: center;
   gap: 6px;
+  padding: 4px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(24, 214, 198, 0.04);
+  color: var(--muted-bright);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+}
+
+.set-cell__done:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(24, 214, 198, 0.1);
+  transform: translateY(-1px);
+}
+
+.set-cell__done:focus-visible {
+  outline: 2px solid rgba(24, 214, 198, 0.55);
+  outline-offset: 2px;
+}
+
+.set-cell__done-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1em;
+  height: 1.1em;
+  font-size: 0.85rem;
+}
+
+.set-cell__done-label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.set-cell__done.is-done {
+  background: linear-gradient(125deg, rgba(24, 214, 198, 0.24), rgba(24, 214, 198, 0.45));
+  border-color: rgba(24, 214, 198, 0.75);
+  color: var(--text-strong);
+  box-shadow: 0 0 0 4px rgba(24, 214, 198, 0.14);
+}
+
+.set-cell__done.is-done .set-cell__done-icon {
+  color: var(--text-strong);
+}
+
+tr.done td {
+  background: rgba(24, 214, 198, 0.08);
+}
+
+@media (max-width: 600px) {
+  .tracker-table {
+    min-width: 100%;
+  }
+
+  .tracker-table thead {
+    display: none;
+  }
+
+  .tracker-table tbody {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .tracker-table tbody tr {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    border: 1px solid rgba(36, 66, 88, 0.6);
+    border-radius: 16px;
+    padding: 14px;
+    background: rgba(9, 19, 30, 0.9);
+  }
+
+  .tracker-table tbody tr.done {
+    background: rgba(24, 214, 198, 0.12);
+  }
+
+  .tracker-table tbody tr.done td {
+    background: transparent;
+  }
+
+  .tracker-table tbody tr td {
+    border: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 13px;
+  }
+
+  .tracker-table tbody tr td::before {
+    content: attr(data-label);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+  }
+
+  .tracker-table tbody tr td[data-label="Set"]::before {
+    letter-spacing: 0.12em;
+  }
+
+  .tracker-table tbody tr td[data-label="Done"] {
+    grid-column: span 2;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .tracker-table tbody tr td[data-label="Done"]::before {
+    margin-bottom: 4px;
+  }
+}
+
+.footer {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+}
+
+.workout-list {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2.4vw, 22px);
+}
+
+.archive-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3.2vw, 32px);
+}
+
+.archive-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.archive-toolbar .archive-count {
+  margin: 0;
+}
+
+@media (min-width: 640px) {
+  .archive-toolbar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.archive-picker {
+  position: relative;
+  width: 100%;
+  max-width: 360px;
+}
+
+.archive-picker__button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(140deg, rgba(9, 23, 34, 0.95), rgba(8, 18, 30, 0.88));
+  color: var(--text-strong);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.archive-picker__button:not(:disabled):hover {
+  box-shadow: 0 16px 32px rgba(12, 32, 48, 0.5);
+  transform: translateY(-1px);
+}
+
+.archive-picker__button:not(:disabled):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(24, 214, 198, 0.32), 0 16px 32px rgba(12, 32, 48, 0.5);
+}
+
+.archive-picker__button:disabled {
+  opacity: 0.72;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.archive-picker__text {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  gap: 2px;
+}
+
+.archive-picker__eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.archive-picker__value {
+  font-size: 15px;
+}
+
+.archive-picker__icon {
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  transition: transform 0.2s ease;
+}
+
+.archive-picker__icon.open {
+  transform: rotate(180deg);
+}
+
+.archive-picker__menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: rgba(6, 16, 26, 0.98);
+  box-shadow: 0 18px 38px rgba(5, 12, 21, 0.65);
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.archive-picker__option {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.archive-picker__option:hover,
+.archive-picker__option:focus-visible {
+  outline: none;
+  background: rgba(24, 214, 198, 0.12);
+  color: var(--text-strong);
+}
+
+.archive-picker__option.selected {
+  background: rgba(24, 214, 198, 0.18);
+  color: var(--text-strong);
+  box-shadow: inset 0 0 0 1px rgba(24, 214, 198, 0.32);
+}
+
+.archive-picker__option-week {
+  font-weight: 600;
+}
+
+.archive-picker__option-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.archive-count {
+  font-size: 13px;
+  color: var(--muted);
+  margin: -4px 0 4px;
+}
+
+.workout-card {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 2.6vw, 28px);
+  background: linear-gradient(160deg, rgba(7, 18, 29, 0.92), rgba(9, 24, 38, 0.88));
+  border: 1px solid rgba(36, 66, 88, 0.6);
+  border-radius: 28px;
+  padding: clamp(20px, 3.2vw, 32px);
+  box-shadow: var(--shadow-soft);
+}
+
+.workout-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (min-width: 760px) {
+  .workout-header {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+}
+
+.workout-header h2 {
+  margin-bottom: 8px;
+}
+
+.workout-tags {
+  display: flex;
+  gap: 10px;
   flex-wrap: wrap;
   align-items: center;
 }
 
-.template-pill {
-  border-style: dashed;
-  opacity: 0.9;
+.workout-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-@media print {
-  body {
-    background: #fff;
-    color: #000;
+.summary-item {
+  background: rgba(7, 24, 36, 0.78);
+  border: 1px solid rgba(36, 66, 88, 0.6);
+  border-radius: 18px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.archive-page .summary-item {
+  background: var(--surface-alt);
+  border-color: var(--border);
+}
+
+.summary-label {
+  display: block;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.summary-value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--text-strong);
+}
+
+.summary-value {
+  font-size: clamp(20px, 4vw, 30px);
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.summary-value-compact {
+  font-size: clamp(14px, 3vw, 16px);
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.summary-subvalue {
+  font-size: 13px;
+  color: var(--muted);
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.pill-active {
+  background: rgba(52, 211, 153, 0.16);
+  border-color: rgba(52, 211, 153, 0.42);
+  color: #5cf5c5;
+}
+
+.pill-archived {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.38);
+  color: #dbeafe;
+}
+
+.archive-page .pill-active {
+  background: rgba(16, 183, 176, 0.16);
+  border-color: rgba(16, 183, 176, 0.38);
+  color: var(--accent-strong);
+}
+
+.archive-page .pill-archived {
+  background: rgba(31, 41, 55, 0.1);
+  border-color: rgba(31, 41, 55, 0.2);
+  color: #3c4a55;
+}
+
+.day-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+}
+
+@media (min-width: 900px) {
+  .day-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-  .btn,
-  .sticky-actions {
-    display: none !important;
+}
+
+@media (min-width: 1260px) {
+  .day-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .card,
-  .exercise {
-    background: #fff;
-    color: #000;
-    border-color: #ddd;
+}
+
+.day-card {
+  background: rgba(7, 18, 30, 0.82);
+  border: 1px solid rgba(44, 78, 100, 0.6);
+  border-radius: 22px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.archive-page .day-carousel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.archive-page .day-track {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  overflow-x: auto;
+  padding: 6px 2px 12px;
+  scroll-snap-type: x mandatory;
+  scroll-padding: 2px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+.archive-page .day-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.archive-page .day-track::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 999px;
+}
+
+.archive-page .day-card {
+  flex: 0 0 min(100%, 360px);
+  width: min(100%, 360px);
+  max-width: min(100%, 360px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow-soft);
+  scroll-snap-align: start;
+}
+
+@media (min-width: 768px) {
+  .archive-page .day-card {
+    flex: 0 0 min(48vw, 400px);
+    width: min(48vw, 400px);
+    max-width: min(48vw, 400px);
   }
-  tr.done td {
-    background: rgba(110, 231, 183, 0.2);
+}
+
+@media (min-width: 1200px) {
+  .archive-page .day-card {
+    flex: 0 0 min(36vw, 420px);
+    width: min(36vw, 420px);
+    max-width: min(36vw, 420px);
+  }
+}
+
+.day-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.day-header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--text-strong);
+}
+
+.day-meta {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.exercise-summary {
+  border-top: 1px solid rgba(44, 78, 100, 0.4);
+  padding-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.exercise-summary:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.archive-page .exercise-summary {
+  border-top: 1px solid var(--border);
+}
+
+.exercise-summary-title {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.exercise-summary-suggested {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.auth-page {
+  min-height: 100vh;
+}
+
+.auth-wrap {
+  align-items: center;
+  gap: clamp(28px, 6vw, 48px);
+}
+
+.auth-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 16px;
+}
+
+.auth-header h1 {
+  margin: 0;
+  font-size: clamp(24px, 4vw, 34px);
+  color: var(--text-strong);
+}
+
+.auth-subtitle {
+  margin: 0;
+  color: var(--muted);
+  max-width: 56ch;
+  font-size: 14px;
+}
+
+.auth-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  border-radius: 999px;
+  background: rgba(24, 214, 198, 0.16);
+  box-shadow: 0 18px 40px rgba(24, 214, 198, 0.18);
+}
+
+.auth-logo__image {
+  width: clamp(78px, 14vw, 110px);
+  height: auto;
+  animation: logoPulse 6s ease-in-out infinite;
+  filter: drop-shadow(0 0 24px rgba(24, 214, 198, 0.4));
+}
+
+@keyframes logoPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 18px rgba(24, 214, 198, 0.36));
+  }
+
+  50% {
+    transform: scale(1.05);
+    filter: drop-shadow(0 0 28px rgba(24, 214, 198, 0.5));
+  }
+}
+
+.auth-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(24, 214, 198, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(24, 214, 198, 0.18);
+}
+
+.auth-toggle button {
+  border: none;
+  background: transparent;
+  color: var(--muted-bright);
+  font-weight: 600;
+  font-size: 13px;
+  padding: 6px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.auth-toggle button:not(.active):hover {
+  color: var(--text-strong);
+}
+
+.auth-toggle button.active {
+  background: rgba(24, 214, 198, 0.95);
+  color: #02141c;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(24, 214, 198, 0.35);
+}
+
+.auth-toggle button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.auth-grid {
+  display: grid;
+  gap: clamp(20px, 4vw, 32px);
+  width: 100%;
+}
+
+@media (min-width: 960px) {
+  .auth-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
+    align-items: stretch;
+  }
+}
+
+.auth-card {
+  width: min(100%, 520px);
+  margin: 0 auto;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.auth-field .in {
+  border-radius: 18px;
+  border: 1px solid rgba(44, 78, 100, 0.7);
+  background: rgba(8, 20, 32, 0.82);
+  color: var(--text-strong);
+  padding: 12px 18px;
+  font-size: 15px;
+  font-weight: 500;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.auth-field .in::placeholder {
+  color: var(--muted);
+  opacity: 0.72;
+}
+
+.auth-field .in:focus {
+  transform: translateY(-1px);
+}
+
+.auth-field span {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted-bright);
+}
+
+.auth-banner {
+  width: 100%;
+}
+
+.auth-profile {
+  gap: 18px;
+}
+
+.auth-profile__list {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-profile__list div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.auth-profile__list dt {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.auth-profile__list dd {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-strong);
+}
+
+.auth-profile__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.auth-profile--empty ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.auth-profile--empty .btn {
+  align-self: flex-start;
+}
+
+.exercise-summary-how {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.exercise-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: 14px;
+  border: 1px solid rgba(36, 66, 88, 0.55);
+  background: rgba(5, 14, 22, 0.92);
+  margin-top: 6px;
+}
+
+.archive-page .exercise-table-wrap {
+  border-color: var(--border);
+  background: var(--surface-alt);
+}
+
+.exercise-table-wrap::-webkit-scrollbar {
+  height: 8px;
+}
+
+.exercise-table-wrap::-webkit-scrollbar-thumb {
+  background: rgba(36, 66, 88, 0.7);
+  border-radius: 999px;
+}
+
+.exercise-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 420px;
+}
+
+.exercise-table th,
+.exercise-table td {
+  font-size: 13px;
+  padding: 10px 12px;
+}
+
+.exercise-table thead {
+  background: rgba(12, 32, 48, 0.72);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.exercise-table th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.archive-page .exercise-table thead {
+  background: rgba(16, 183, 176, 0.14);
+  color: var(--accent-strong);
+}
+
+.archive-page .exercise-table th {
+  color: var(--muted);
+}
+
+.archive-page .exercise-table {
+  min-width: 100%;
+  table-layout: fixed;
+}
+
+.archive-page .exercise-table th,
+.archive-page .exercise-table td {
+  white-space: nowrap;
+}
+
+@media (max-width: 540px) {
+  .archive-page .exercise-table th,
+  .archive-page .exercise-table td {
+    font-size: 12px;
+    padding: 8px 10px;
+  }
+}
+
+.exercise-table tbody tr {
+  border-top: 1px solid rgba(36, 66, 88, 0.45);
+}
+
+.archive-page .exercise-table tbody tr {
+  border-top: 1px solid rgba(12, 116, 114, 0.18);
+}
+
+.exercise-table tbody tr:nth-child(even) {
+  background: rgba(10, 26, 40, 0.52);
+}
+
+.archive-page .exercise-table tbody tr:nth-child(even) {
+  background: rgba(16, 183, 176, 0.08);
+}
+
+.exercise-table td:last-child {
+  text-align: center;
+}
+
+.exercise-summary-footer {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 4px;
+  text-align: right;
+}
+
+.hidden {
+  display: none;
+}
+
+
+.progress-page {
+  min-height: 100vh;
+  padding: clamp(32px, 7vw, 80px) 0;
+  background:
+    radial-gradient(circle at 14% 12%, rgba(24, 214, 198, 0.16), transparent 58%),
+    radial-gradient(circle at 88% -6%, rgba(11, 139, 208, 0.2), transparent 62%),
+    var(--bg);
+}
+
+.progress-wrap {
+  gap: clamp(24px, 4vw, 36px);
+}
+
+.progress-hero {
+  gap: clamp(18px, 3vw, 24px);
+  background: linear-gradient(150deg, rgba(6, 20, 32, 0.96), rgba(9, 26, 40, 0.86));
+  border: 1px solid rgba(36, 82, 106, 0.55);
+}
+
+.progress-hero::before {
+  inset: -160px -120px auto auto;
+  width: 320px;
+  height: 320px;
+  opacity: 0.55;
+}
+
+.progress-hero__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress-hero__actions {
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.progress-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+.progress-summary-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(12px, 3vw, 18px);
+}
+
+@media (min-width: 720px) {
+  .progress-summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.progress-summary-card {
+  background: linear-gradient(150deg, rgba(11, 24, 36, 0.9), rgba(6, 18, 30, 0.82));
+  border: 1px solid rgba(40, 76, 100, 0.55);
+  border-radius: 22px;
+  padding: clamp(18px, 3vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: 0 20px 38px rgba(5, 12, 20, 0.45);
+}
+
+.progress-summary-card--accent {
+  background: linear-gradient(150deg, rgba(24, 214, 198, 0.18), rgba(11, 122, 168, 0.16));
+  border-color: rgba(24, 214, 198, 0.45);
+  box-shadow: 0 24px 48px rgba(24, 214, 198, 0.16);
+}
+
+.progress-summary-label {
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-summary-value {
+  margin: 0;
+  font-size: clamp(24px, 5vw, 36px);
+  font-weight: 700;
+  color: var(--text-strong);
+  line-height: 1.15;
+}
+
+.progress-summary-sub {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted-bright);
+}
+
+.progress-summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(24, 214, 198, 0.35);
+  background: rgba(24, 214, 198, 0.18);
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(20px, 4vw, 28px);
+}
+
+@media (min-width: 980px) {
+  .progress-grid {
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+  }
+
+  .progress-card--full {
+    grid-column: 1 / -1;
+  }
+}
+
+.progress-card {
+  background: linear-gradient(150deg, rgba(7, 18, 28, 0.92), rgba(9, 24, 36, 0.86));
+  border: 1px solid rgba(34, 70, 94, 0.55);
+  border-radius: 24px;
+  padding: clamp(18px, 3vw, 26px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 3vw, 22px);
+  box-shadow: var(--shadow-soft);
+}
+
+.progress-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.progress-card__header > * {
+  min-width: 0;
+}
+
+@media (max-width: 640px) {
+  .progress-card__header {
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .progress-card__meta {
+    order: 3;
+  }
+}
+
+.progress-card__header h2 {
+  margin: 0;
+  font-size: clamp(18px, 3.2vw, 24px);
+  color: var(--text-strong);
+}
+
+.progress-card__meta {
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-line-chart,
+.progress-bar-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.progress-line-chart__svg,
+.progress-bar-chart__svg {
+  width: 100%;
+  height: auto;
+}
+
+.progress-line-chart__grid-line {
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1;
+}
+
+.progress-line-chart__grid-line.is-zero {
+  stroke: rgba(24, 214, 198, 0.36);
+}
+
+.progress-line-chart__axis-label {
+  fill: var(--muted);
+  font-size: 11px;
+  text-anchor: end;
+}
+
+.progress-line-chart__area {
+  opacity: 0.75;
+}
+
+.progress-line-chart__line {
+  stroke-width: 4;
+  filter: drop-shadow(0 10px 22px rgba(24, 214, 198, 0.2));
+}
+
+.progress-line-chart__dot {
+  fill: var(--accent);
+  stroke: rgba(3, 8, 15, 0.9);
+  stroke-width: 3;
+}
+
+.progress-line-chart__value {
+  fill: var(--muted-bright);
+  font-size: 12px;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.progress-line-chart__labels,
+.progress-bar-chart__labels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 10px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.progress-line-chart__labels span,
+.progress-bar-chart__labels span {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+}
+
+.progress-line-chart__label-value,
+.progress-bar-chart__label-value {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.progress-line-chart__label-text,
+.progress-bar-chart__label-text {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-bar-chart__baseline {
+  stroke: rgba(255, 255, 255, 0.08);
+  stroke-width: 1;
+}
+
+.progress-bar-chart__bar {
+  filter: drop-shadow(0 14px 26px rgba(24, 214, 198, 0.18));
+}
+
+.progress-bar-chart__value {
+  fill: var(--muted-bright);
+  font-size: 12px;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.progress-chart__empty {
+  color: var(--muted);
+  font-size: 13px;
+  margin: 8px 0 0;
+}
+
+.progress-focus {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vw, 24px);
+}
+
+.progress-focus__top {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+@media (min-width: 860px) {
+  .progress-focus__top {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.progress-focus__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress-focus__intro h2 {
+  margin: 0;
+  font-size: clamp(20px, 4vw, 28px);
+  color: var(--text-strong);
+}
+
+.progress-focus__meta {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.progress-delta {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.progress-delta--positive {
+  color: var(--success);
+}
+
+.progress-delta--negative {
+  color: var(--danger);
+}
+
+.progress-delta--neutral {
+  color: var(--muted);
+}
+
+.progress-focus__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.progress-focus__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.progress-segmented {
+  display: inline-flex;
+  background: rgba(7, 18, 28, 0.72);
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  border-radius: 999px;
+  padding: 4px;
+  gap: 4px;
+}
+
+.progress-segmented__option {
+  border: 0;
+  background: transparent;
+  color: var(--muted-bright);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.progress-segmented__option:hover {
+  color: var(--text-strong);
+}
+
+.progress-segmented__option.is-active {
+  background: linear-gradient(120deg, rgba(24, 214, 198, 0.24), rgba(11, 139, 208, 0.2));
+  color: var(--text-strong);
+  box-shadow: 0 12px 24px rgba(24, 214, 198, 0.18);
+}
+
+.progress-calendar-toggle {
+  position: relative;
+}
+
+.progress-calendar-toggle__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  background: rgba(7, 18, 28, 0.72);
+  color: var(--muted-bright);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.progress-calendar-toggle__button:hover {
+  color: var(--text-strong);
+  border-color: rgba(24, 214, 198, 0.5);
+}
+
+.progress-calendar-toggle__button svg {
+  width: 16px;
+  height: 16px;
+  transition: transform 0.2s ease;
+}
+
+.progress-calendar-toggle__button.is-open svg {
+  transform: rotate(180deg);
+}
+
+.progress-calendar {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  width: min(340px, 90vw);
+  max-height: 420px;
+  overflow-y: auto;
+  background: rgba(3, 10, 18, 0.96);
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  border-radius: 18px;
+  padding: 18px;
+  box-shadow: 0 26px 50px rgba(2, 8, 14, 0.45);
+  backdrop-filter: blur(18px);
+  z-index: 5;
+}
+
+@media (max-width: 640px) {
+  .progress-calendar {
+    left: 0;
+    right: auto;
+  }
+}
+
+.progress-calendar__empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.progress-calendar__month {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.progress-calendar__month:last-child {
+  margin-bottom: 0;
+}
+
+.progress-calendar__month-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-calendar__week-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.progress-calendar__week {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(7, 18, 28, 0.72);
+  border-radius: 14px;
+  border: 1px solid rgba(34, 70, 94, 0.5);
+  padding: 10px 12px;
+}
+
+.progress-calendar__week-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  border: 0;
+  background: none;
+  color: var(--muted-bright);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.progress-calendar__week-button:hover {
+  color: var(--text-strong);
+}
+
+.progress-calendar__week-button.is-active {
+  color: var(--accent);
+}
+
+.progress-calendar__week-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+}
+
+.progress-calendar__week-meta {
+  font-size: 12px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.progress-calendar__day-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 8px;
+}
+
+.progress-calendar__day-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  border-radius: 12px;
+  background: rgba(2, 10, 18, 0.72);
+  padding: 10px;
+  color: var(--muted-bright);
+  font-size: 12px;
+  font-weight: 600;
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.progress-calendar__day-button:hover {
+  border-color: rgba(24, 214, 198, 0.5);
+  color: var(--text-strong);
+}
+
+.progress-calendar__day-button.is-active {
+  border-color: rgba(24, 214, 198, 0.6);
+  color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(24, 214, 198, 0.18);
+}
+
+.progress-calendar__day-weekday {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-calendar__day-number {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.progress-calendar__day-percent {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.progress-week-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  padding: 6px 0 0;
+}
+
+.progress-week-picker__option {
+  background: rgba(7, 18, 28, 0.78);
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  border-radius: 14px;
+  padding: 10px 14px;
+  color: var(--muted-bright);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 96px;
+  flex: 1 1 calc(50% - 10px);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.progress-week-picker__option strong {
+  font-size: 14px;
+  color: var(--text-strong);
+}
+
+@media (min-width: 720px) {
+  .progress-week-picker {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding: 4px 6px 6px;
+    margin: 0 -6px;
+    scrollbar-width: none;
+  }
+
+  .progress-week-picker::-webkit-scrollbar {
+    height: 0;
+    width: 0;
+  }
+
+  .progress-week-picker__option {
+    flex: 0 0 auto;
+    min-width: 76px;
+  }
+}
+
+.progress-week-picker__option:hover {
+  transform: translateY(-2px);
+  border-color: rgba(24, 214, 198, 0.45);
+  color: var(--text-strong);
+}
+
+.progress-week-picker__option[aria-selected="true"] {
+  background: linear-gradient(140deg, rgba(24, 214, 198, 0.28), rgba(11, 139, 208, 0.2));
+  color: var(--text-strong);
+  border-color: rgba(24, 214, 198, 0.6);
+  box-shadow: 0 16px 30px rgba(24, 214, 198, 0.18);
+  transform: translateY(-1px);
+}
+
+.progress-day-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
+.progress-day-picker__option {
+  border: 1px solid rgba(36, 74, 98, 0.6);
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: rgba(7, 18, 28, 0.72);
+  color: var(--muted-bright);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.progress-day-picker__option:hover {
+  color: var(--text-strong);
+  border-color: rgba(24, 214, 198, 0.4);
+}
+
+.progress-day-picker__option.is-active {
+  background: linear-gradient(140deg, rgba(24, 214, 198, 0.24), rgba(11, 139, 208, 0.18));
+  border-color: rgba(24, 214, 198, 0.55);
+  color: var(--text-strong);
+  box-shadow: 0 16px 30px rgba(24, 214, 198, 0.18);
+}
+
+.progress-day-picker__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.progress-day-picker__meta {
+  font-size: 14px;
+  color: var(--accent);
+}
+
+.progress-focus__empty {
+  background: rgba(7, 18, 28, 0.72);
+  border: 1px dashed rgba(36, 74, 98, 0.6);
+  border-radius: 14px;
+  padding: 18px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.progress-exercise-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.progress-exercise {
+  background: rgba(7, 18, 28, 0.78);
+  border: 1px solid rgba(34, 70, 94, 0.5);
+  border-radius: 16px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress-exercise__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.progress-exercise__title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.progress-exercise__target {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.progress-exercise__percent {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.progress-exercise__meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.progress-day-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.progress-day {
+  background: rgba(7, 18, 28, 0.78);
+  border: 1px solid rgba(34, 70, 94, 0.5);
+  border-radius: 18px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress-day__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.progress-day__title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--text-strong);
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+.progress-day__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(24, 214, 198, 0.12);
+  color: var(--accent);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.progress-day__percent {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-strong);
+  flex-shrink: 0;
+}
+
+.progress-day__meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.progress-bar {
+  width: 100%;
+  height: 8px;
+  background: rgba(24, 214, 198, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar__value {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(24, 214, 198, 0.85), rgba(11, 139, 208, 0.7));
+  box-shadow: 0 12px 26px rgba(24, 214, 198, 0.25);
+  transition: width 0.4s ease;
+}
+
+.progress-ring {
+  width: min(180px, 45vw);
+  align-self: center;
+}
+
+.progress-ring svg {
+  width: 100%;
+  height: auto;
+}
+
+.progress-ring__bg {
+  stroke: rgba(24, 214, 198, 0.12);
+}
+
+.progress-ring__value {
+  filter: drop-shadow(0 14px 26px rgba(24, 214, 198, 0.18));
+}
+
+.progress-ring__label {
+  fill: var(--text-strong);
+  font-size: 26px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.progress-ring__sub {
+  fill: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-anchor: middle;
+}
+
+.progress-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.progress-timeline__item {
+  background: rgba(7, 18, 28, 0.75);
+  border: 1px solid rgba(34, 70, 94, 0.45);
+  border-radius: 16px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.progress-timeline__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.progress-timeline__title {
+  font-weight: 600;
+  color: var(--text-strong);
+  flex: 1 1 220px;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.progress-timeline__percent {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.progress-timeline__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+
+.progress-empty {
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.progress-empty__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0px) scale(1);
+  }
+
+  50% {
+    transform: translateY(-4px) scale(1.02);
+  }
+}
+
+@keyframes drift {
+  0%,
+  100% {
+    transform: rotate(12deg) translate(0, 0);
+    opacity: 0.8;
+  }
+
+  50% {
+    transform: rotate(5deg) translate(18px, -10px);
+    opacity: 0.55;
+  }
+}
+
+@keyframes halo {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+
+  50% {
+    transform: scale(1.18);
+    opacity: 0.75;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,9 @@ import type { ReactNode } from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "30-Min Gym Checklist (Beginner, RPE ~6)",
-  description: "Beginner-friendly 30 minute gym workout checklist with auto-save and weekly archive"
+  title: "Fitmotion Trainer · 30-Min Gym Checklist (RPE ~6)",
+  description:
+    "Stay on track with the Fitmotion beginner checklist — auto-saving workouts, shareable progress, and a MongoDB archive."
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,38 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DayEntry, WeekResponse } from "@/lib/week";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
 const ACTIVE_DAY_STORAGE_KEY = "rpe6_active_day";
+const USER_STORAGE_KEY = "fitmotion_user";
 
 type FieldKey = "weight" | "repsOrSec" | "rpe" | "done";
+
+type PlanOption = {
+  value: number;
+  key: string;
+  label: string;
+};
+
+type StoredUser = {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string | null;
+};
+
+const PLAN_OPTIONS: PlanOption[] = [
+  { value: 0, key: "foundation", label: "Beginner" },
+  { value: 1, key: "athletic", label: "Intermediate" },
+  { value: 2, key: "apex", label: "Advanced" }
+];
 
 type ConfirmState = {
   message: string;
@@ -46,55 +70,110 @@ function getStatusClass(state: SaveState) {
   }
 }
 
-function exportWeekToCsv(week: WeekResponse) {
-  const rows: string[][] = [[
-    "weekOf",
-    "templateTitle",
-    "day",
-    "exercise",
-    "set",
-    "weight",
-    "repsOrSec",
-    "rpe",
-    "done",
-    "exportedAt"
-  ]];
-  const now = new Date().toISOString();
+function getDayTotals(day: DayEntry) {
+  return day.exercises.reduce(
+    (acc, exercise) => {
+      const doneSets = exercise.sets.filter((set) => Boolean(set.done)).length;
+      acc.completed += doneSets;
+      acc.total += exercise.sets.length;
+      return acc;
+    },
+    { completed: 0, total: 0 }
+  );
+}
+
+function collectUnique(values: string[]) {
+  const trimmed = values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return Array.from(new Set(trimmed));
+}
+
+function buildWeekShareSummary(week: WeekResponse) {
+  let aggregateCompleted = 0;
+  let aggregateTotal = 0;
 
   week.days.forEach((day) => {
-    day.exercises.forEach((exercise) => {
-      exercise.sets.forEach((set) => {
-        rows.push([
-          week.weekOf,
-          week.templateTitle,
-          day.name,
-          exercise.name,
-          String(set.set),
-          set.weight,
-          set.repsOrSec,
-          set.rpe,
-          set.done ? "1" : "0",
-          now
-        ]);
-      });
-    });
+    const { completed, total } = getDayTotals(day);
+    aggregateCompleted += completed;
+    aggregateTotal += total;
   });
 
-  const csv = rows
-    .map((row) => row.map((value) => `"${String(value).replace(/"/g, '""')}"`).join(","))
-    .join("\n");
+  const lines: string[] = [
+    `Fitmotion · Week of ${week.weekOf}`,
+    `${week.templateTitle} — ${week.description}`,
+    `Progress: ${aggregateCompleted}/${aggregateTotal} sets complete`,
+    ""
+  ];
 
-  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `rpe6-checklist-${week.weekOf}.csv`;
-  link.click();
-  URL.revokeObjectURL(url);
+  week.days.forEach((day) => {
+    const { completed, total } = getDayTotals(day);
+    lines.push(`${day.name}: ${completed}/${total} sets complete`);
+
+    day.exercises.forEach((exercise) => {
+      const doneSets = exercise.sets.filter((set) => Boolean(set.done)).length;
+      const weights = collectUnique(exercise.sets.map((set) => set.weight));
+      const repsOrSeconds = collectUnique(exercise.sets.map((set) => set.repsOrSec));
+      const rpes = collectUnique(exercise.sets.map((set) => set.rpe));
+      const detailParts: string[] = [];
+
+      if (weights.length > 0) {
+        detailParts.push(`wt ${weights.join("/")}`);
+      }
+      if (repsOrSeconds.length > 0) {
+        detailParts.push(`${exercise.type === "seconds" ? "sec" : "reps"} ${repsOrSeconds.join("/")}`);
+      }
+      if (rpes.length > 0) {
+        detailParts.push(`RPE ${rpes.join("/")}`);
+      }
+      detailParts.push(`${doneSets}/${exercise.sets.length} done`);
+
+      lines.push(`  • ${exercise.name}: ${detailParts.join(" · ")}`);
+    });
+
+    lines.push("");
+  });
+
+  lines.push("Shared from Fitmotion Trainer");
+
+  return lines.join("\n").trim();
+}
+
+async function copyToClipboard(text: string) {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.error("Clipboard API failed", error);
+    }
+  }
+
+  if (typeof document !== "undefined") {
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.top = "-9999px";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      return true;
+    } catch (error) {
+      console.error("execCommand copy failed", error);
+    }
+  }
+
+  return false;
 }
 
 export default function HomePage() {
   const [week, setWeek] = useState<WeekResponse | null>(null);
+  const [selectedPlanIndex, setSelectedPlanIndex] = useState(0);
   const [activeDayIndex, setActiveDayIndex] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -102,17 +181,32 @@ export default function HomePage() {
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const [newWeekLoading, setNewWeekLoading] = useState(false);
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null);
+  const [currentUser, setCurrentUser] = useState<StoredUser | null>(null);
+  const [userLoaded, setUserLoaded] = useState(false);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef(false);
   const initialLoadRef = useRef(true);
+  const previousUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (!userLoaded) {
+      return;
+    }
+
+    const normalizedUserId = currentUser?.id ?? null;
+
+    if (previousUserIdRef.current !== normalizedUserId) {
+      previousUserIdRef.current = normalizedUserId;
+      setWeek(null);
+    }
+
     let isMounted = true;
 
-    async function loadWeek() {
+    async function loadWeek(targetUserId: string | null) {
       try {
         setLoading(true);
-        const response = await fetch("/api/week", { cache: "no-store" });
+        const search = targetUserId ? `?userId=${encodeURIComponent(targetUserId)}` : "";
+        const response = await fetch(`/api/week${search}`, { cache: "no-store" });
         if (!response.ok) {
           throw new Error(`Request failed with status ${response.status}`);
         }
@@ -121,6 +215,7 @@ export default function HomePage() {
         pendingRef.current = false;
         initialLoadRef.current = true;
         setWeek(data.week);
+        setSelectedPlanIndex(data.week.templateIndex);
         setSaveState("saved");
         setError(null);
         setNotice(null);
@@ -137,12 +232,54 @@ export default function HomePage() {
       }
     }
 
-    loadWeek();
+    void loadWeek(normalizedUserId);
 
     return () => {
       isMounted = false;
     };
+  }, [userLoaded, currentUser?.id]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setUserLoaded(true);
+      return;
+    }
+
+    function readUser(raw: string | null) {
+      if (!raw) {
+        setCurrentUser(null);
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(raw) as StoredUser;
+        setCurrentUser(parsed);
+      } catch (storageError) {
+        console.error("Failed to parse stored user", storageError);
+        setCurrentUser(null);
+      }
+    }
+
+    readUser(window.localStorage.getItem(USER_STORAGE_KEY));
+    setUserLoaded(true);
+
+    function handleStorage(event: StorageEvent) {
+      if (event.key === USER_STORAGE_KEY) {
+        readUser(event.newValue);
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
   }, []);
+
+  useEffect(() => {
+    if (week) {
+      setSelectedPlanIndex(week.templateIndex);
+    }
+  }, [week]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -188,7 +325,11 @@ export default function HomePage() {
         const response = await fetch("/api/week", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ id: week.id, days: week.days })
+          body: JSON.stringify({
+            id: week.id,
+            days: week.days,
+            userId: week.userId ?? null
+          })
         });
         if (!response.ok) {
           throw new Error(`Request failed with status ${response.status}`);
@@ -221,6 +362,105 @@ export default function HomePage() {
     return week.days[activeDayIndex] ?? week.days[0];
   }, [week, activeDayIndex]);
 
+  const currentPlanOption = useMemo(() => {
+    const planIndex = week?.templateIndex ?? 0;
+    return PLAN_OPTIONS.find((option) => option.value === planIndex) ?? PLAN_OPTIONS[0];
+  }, [week?.templateIndex]);
+
+  const greetingName = useMemo(() => {
+    if (!currentUser?.name) {
+      return null;
+    }
+    const trimmed = currentUser.name.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const [first] = trimmed.split(/\s+/);
+    return first ?? trimmed;
+  }, [currentUser?.name]);
+
+  const heroBrand = (
+    <div className="home-hero__brand">
+      <div className="home-hero__logo">
+        <Image
+          alt="Fitmotion logo"
+          className="home-hero__logo-image"
+          height={88}
+          priority
+          src="/fitmotion-logo.svg"
+          width={88}
+        />
+      </div>
+      <div className="home-hero__title">
+        <p className="eyebrow">Fitmotion Trainer</p>
+        <h1>Weekly Workouts</h1>
+        {greetingName && (
+          <p className="home-hero__welcome">Welcome back, {greetingName}!</p>
+        )}
+      </div>
+    </div>
+  );
+
+  const ownerId = currentUser?.id ?? week?.userId ?? null;
+  const workoutsHref = ownerId ? `/workouts?userId=${encodeURIComponent(ownerId)}` : "/workouts";
+  const progressHref = ownerId ? `/progress?userId=${encodeURIComponent(ownerId)}` : "/progress";
+
+  const heroActions = (
+    <div className="home-hero__actions">
+      <Link className="btn ghost home-hero__link" href={workoutsHref}>
+        <span>View saved weeks</span>
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M5 10h8.17l-2.58-2.59L11 6l5 5-5 5-1.41-1.41L13.17 12H5z"
+            fill="currentColor"
+          />
+        </svg>
+      </Link>
+      <Link className="btn ghost home-hero__link" href={progressHref}>
+        <span>Progress insights</span>
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3.5 13.5 7.75 9.25 11 12.5 16.5 7"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+          />
+          <path
+            d="M16.5 11V7h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+          />
+        </svg>
+      </Link>
+      <Link className="btn ghost home-hero__link" href="/auth">
+        <span>Log in / Register</span>
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M5 10h8.17l-2.58-2.59L11 6l5 5-5 5-1.41-1.41L13.17 12H5z" fill="currentColor" />
+        </svg>
+      </Link>
+    </div>
+  );
+
   function markPending() {
     pendingRef.current = true;
     setSaveState("saving");
@@ -238,6 +478,9 @@ export default function HomePage() {
 
   function cancelConfirm() {
     setConfirmState(null);
+    if (week) {
+      setSelectedPlanIndex(week.templateIndex);
+    }
   }
 
   function updateSet(
@@ -312,16 +555,31 @@ export default function HomePage() {
     });
   }
 
-  async function startNewWeek(currentWeek: WeekResponse) {
+  async function startNewWeek(currentWeek: WeekResponse, templateIndex?: number, successMessage?: string) {
     try {
       setNewWeekLoading(true);
       setNotice(null);
       setSaveState("saving");
       setError(null);
+      const payload: {
+        id: string;
+        days: WeekResponse["days"];
+        templateIndex?: number;
+        userId: string | null;
+      } = {
+        id: currentWeek.id,
+        days: currentWeek.days,
+        userId: currentWeek.userId ?? currentUser?.id ?? null
+      };
+
+      if (typeof templateIndex === "number") {
+        payload.templateIndex = templateIndex;
+      }
+
       const response = await fetch("/api/week/new", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: currentWeek.id, days: currentWeek.days })
+        body: JSON.stringify(payload)
       });
       if (!response.ok) {
         throw new Error(`Request failed with status ${response.status}`);
@@ -330,15 +588,19 @@ export default function HomePage() {
       pendingRef.current = false;
       initialLoadRef.current = true;
       setWeek(data.week);
+      setSelectedPlanIndex(data.week.templateIndex);
       setActiveDayIndex(0);
       setSaveState("saved");
       setError(null);
-      setNotice("New week loaded! Your previous week was archived.");
+      setNotice(successMessage ?? "New week loaded. Your previous week was archived.");
     } catch (err) {
       console.error(err);
       setError("Unable to start a new week. Please try again.");
       setSaveState("error");
       setNotice(null);
+      if (typeof templateIndex === "number") {
+        setSelectedPlanIndex(currentWeek.templateIndex);
+      }
     } finally {
       setNewWeekLoading(false);
     }
@@ -358,15 +620,77 @@ export default function HomePage() {
     });
   }
 
-  function handleExport() {
+  function handlePlanSelect(event: ChangeEvent<HTMLSelectElement>) {
     if (!week) return;
-    exportWeekToCsv(week);
+    const nextIndex = Number.parseInt(event.target.value, 10);
+    if (Number.isNaN(nextIndex)) {
+      return;
+    }
+    setSelectedPlanIndex(nextIndex);
+    if (nextIndex === week.templateIndex) {
+      setConfirmState(null);
+      return;
+    }
+
+    const option = PLAN_OPTIONS.find((item) => item.value === nextIndex);
+
+    setConfirmState({
+      message: option
+        ? `Switch to the ${option.label} plan? Your current week will be archived.`
+        : "Switch to the selected plan? Your current week will be archived.",
+      confirmLabel: "Switch plan",
+      onConfirm: () => {
+        setConfirmState(null);
+        void startNewWeek(
+          week,
+          nextIndex,
+          option ? `${option.label} plan ready. Your previous week was archived.` : undefined
+        );
+      }
+    });
   }
 
-  function handlePrint() {
-    if (typeof window !== "undefined") {
-      window.print();
+  async function handleShare() {
+    if (!week) return;
+
+    setNotice(null);
+
+    const summary = buildWeekShareSummary(week);
+
+    if (typeof navigator !== "undefined" && "share" in navigator) {
+      const shareNavigator = navigator as Navigator & {
+        share: (data: ShareData) => Promise<void>;
+        canShare?: (data: ShareData) => boolean;
+      };
+
+      const shareData: ShareData = {
+        title: `Fitmotion · Week of ${week.weekOf}`,
+        text: summary
+      };
+
+      try {
+        if (!shareNavigator.canShare || shareNavigator.canShare(shareData)) {
+          await shareNavigator.share(shareData);
+          setNotice("Share sheet opened — send it to complete.");
+          return;
+        }
+      } catch (error) {
+        const domError = error as DOMException | undefined;
+        if (domError?.name === "AbortError") {
+          return;
+        }
+        console.error("Share failed", error);
+      }
     }
+
+    const copied = await copyToClipboard(summary);
+
+    if (copied) {
+      setNotice("Week summary copied. Paste it anywhere to share.");
+      return;
+    }
+
+    setError("Sharing isn't supported in this browser. Try copying your progress manually.");
   }
 
   if (loading && !week) {
@@ -380,28 +704,54 @@ export default function HomePage() {
   if (!week) {
     return (
       <div className="wrap">
-        <h1>30-Min Gym Checklist — Beginner (RPE ~6)</h1>
-        <p className="sub">We couldn't load your workouts.</p>
-        {error && <p className="sub dangerc">{error}</p>}
+        <header className="hero home-hero">
+          <div className="home-hero__layout home-hero__layout--simple">
+            {heroBrand}
+            <div className="home-hero__plan-summary home-hero__plan-summary--empty">
+              <p className="home-hero__plan-title">We couldn’t load your workouts.</p>
+              <p className="home-hero__description">
+                Try refreshing the page and we’ll get your plan ready.
+              </p>
+            </div>
+            {heroActions}
+          </div>
+        </header>
+        {error && (
+          <div className="banner error">
+            <span>{error}</span>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
     <div className="wrap">
-      <header>
-        <div>
-          <h1>30-Min Gym Checklist — Beginner (RPE ~6)</h1>
-          <div className="sub">
-            3 days/week • “Somewhat hard, still comfortable” • Auto-saves to your account
+      <header className="hero home-hero">
+        <div className="home-hero__layout">
+          {heroBrand}
+          <label className="home-field home-hero__field home-hero__level" htmlFor="plan-level">
+            <span>Level</span>
+            <select
+              className="in home-hero__select"
+              id="plan-level"
+              onChange={handlePlanSelect}
+              value={String(selectedPlanIndex)}
+              disabled={newWeekLoading}
+            >
+              {PLAN_OPTIONS.map((option) => (
+                <option key={option.value} value={String(option.value)}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="home-hero__plan-summary">
+            <p className="home-hero__plan-label">{currentPlanOption.label} plan</p>
+            <p className="home-hero__plan-title">{week.templateTitle}</p>
+            <p className="home-hero__description">{week.description}</p>
           </div>
-        </div>
-        <div className="legend">
-          <span className="badge">
-            <strong>RPE 6</strong> ≈ 4 reps in reserve
-          </span>
-          <span className="badge">Breathe smooth</span>
-          <span className="badge">No maxing out</span>
+          {heroActions}
         </div>
       </header>
 
@@ -441,172 +791,195 @@ export default function HomePage() {
 
       <div className="sticky-actions">
         <div className="topbar">
-          <div className="tab-group">
-            {week.days.map((day, idx) => (
-              <button
-                key={day.id}
-                className={classNames("pill", idx === activeDayIndex && "active")}
-                onClick={() => setActiveDayIndex(idx)}
-                title={day.name}
-                type="button"
-              >
-                {day.shortName}
-              </button>
-            ))}
-            <span className="pill">Week of {week.weekOf}</span>
-            <span className="pill template-pill" title={week.description}>
-              {week.templateTitle}
-            </span>
+          <div className="topbar__primary">
+            <h2 className="topbar__title">
+              Today’s Plan
+            </h2>
+            <div className="tab-scroll">
+            <div className="tab-group">
+              {week.days.map((day, idx) => (
+                <button
+                  key={day.id}
+                  className={classNames("pill", idx === activeDayIndex && "active")}
+                    onClick={() => setActiveDayIndex(idx)}
+                    title={day.name}
+                    type="button"
+                  >
+                    {day.shortName}
+                  </button>
+                ))}
+                <span className="pill">Week of {week.weekOf}</span>
+              </div>
+            </div>
           </div>
-          <span className="spacer" />
-          <span className={getStatusClass(saveState)}>{formatStatus(saveState)}</span>
-          <button className="btn" onClick={handlePrint} type="button" title="Print or Save as PDF">
-            🖨️ Print
-          </button>
-          <button className="btn" onClick={handleExport} type="button" title="Export your data as CSV">
-            ⬇️ Export CSV
-          </button>
-          <button
-            className="btn warn"
-            onClick={handleNewWeek}
-            type="button"
-            title="Archive current data and start fresh"
-            disabled={newWeekLoading}
-          >
-            {newWeekLoading ? "⏳ Loading…" : "🗓️ New Week"}
-          </button>
-          <button
-            className="btn danger"
-            onClick={handleResetDay}
-            type="button"
-            title="Clear the current day only"
-          >
-            ♻️ Reset Day
-          </button>
+          <div className="topbar__secondary">
+            <span className={getStatusClass(saveState)}>{formatStatus(saveState)}</span>
+            <div className="topbar__actions">
+              <button
+                aria-label="Share week summary"
+                className="btn"
+                onClick={() => {
+                  void handleShare();
+                }}
+                type="button"
+                title="Share a summary of your progress"
+              >
+                <span aria-hidden>📤</span>
+                <span className="sr-only">Share</span>
+              </button>
+              <button
+                className="btn warn"
+                onClick={handleNewWeek}
+                type="button"
+                title="Archive current data and start fresh"
+                disabled={newWeekLoading}
+              >
+                {newWeekLoading ? "⏳ Loading…" : "🗓️ New Week"}
+              </button>
+              <button
+                className="btn danger"
+                onClick={handleResetDay}
+                type="button"
+                title="Clear the current day only"
+              >
+                ♻️ Reset Day
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
       <div className="grid">
         <div className="card">
-          <h2>Today's Plan</h2>
+          <h2 className="card-title card-title--desktop">Today’s Plan</h2>
           {!activeDay ? (
             <p>No day selected.</p>
           ) : (
             <div>
-              {activeDay.exercises.map((exercise, exerciseIndex) => (
-                <div className="exercise" key={`${exercise.name}-${exerciseIndex}`}>
-                  <header>
-                    <h3>
-                      {exercise.name}{" "}
-                      <span className="muted small">({exercise.target})</span>
-                    </h3>
-                  </header>
-                  <div className="how">{exercise.how}</div>
-                  <div className="sets">
-                    <table>
+              {activeDay.exercises.map((exercise, exerciseIndex) => {
+                const metricLabel = exercise.type === "seconds" ? "Seconds" : "Reps";
+
+                return (
+                  <div className="exercise" key={`${exercise.name}-${exerciseIndex}`}>
+                    <header>
+                      <div className="exercise__title">
+                        <h3>
+                          {exercise.name}{" "}
+                          <span className="muted small">({exercise.target})</span>
+                        </h3>
+                        {exercise.suggestedWeight && (
+                          <p className="muted small exercise__suggested">
+                            Suggested: {exercise.suggestedWeight}
+                          </p>
+                        )}
+                      </div>
+                    </header>
+                    <details className="how">
+                      <summary>Form cues</summary>
+                      <p>{exercise.how}</p>
+                    </details>
+                    <div className="sets">
+                      <table className="tracker-table">
                       <thead>
                         <tr>
                           <th>Set</th>
                           <th>Weight</th>
-                          <th>{exercise.type === "seconds" ? "Seconds" : "Reps"}</th>
+                          <th>{metricLabel}</th>
                           <th>RPE</th>
-                          <th>Done</th>
                         </tr>
                       </thead>
                       <tbody>
-                        {exercise.sets.map((set, setIndex) => (
-                          <tr key={`${exercise.name}-${setIndex}`} className={set.done ? "done" : undefined}>
-                            <td>{set.set}</td>
-                            <td>
-                              <input
-                                className="in"
-                                type="text"
-                                inputMode="decimal"
-                                placeholder="lbs"
-                                value={set.weight}
-                                onChange={(event) =>
-                                  updateSet(activeDayIndex, exerciseIndex, setIndex, "weight", event.target.value)
-                                }
-                              />
-                            </td>
-                            <td>
-                              <input
-                                className="in"
-                                type="text"
-                                inputMode="numeric"
-                                placeholder={exercise.type === "seconds" ? "sec" : "reps"}
-                                value={set.repsOrSec}
-                                onChange={(event) =>
-                                  updateSet(activeDayIndex, exerciseIndex, setIndex, "repsOrSec", event.target.value)
-                                }
-                              />
-                            </td>
-                            <td>
-                              <select
-                                className="in"
-                                value={set.rpe}
-                                onChange={(event) =>
-                                  updateSet(activeDayIndex, exerciseIndex, setIndex, "rpe", event.target.value)
-                                }
-                              >
-                                <option value="">--</option>
-                                <option value="5">5</option>
-                                <option value="6">6</option>
-                                <option value="7">7</option>
-                                <option value="8">8</option>
-                              </select>
-                            </td>
-                            <td>
-                              <input
-                                className="chk"
-                                type="checkbox"
-                                checked={set.done}
-                                onChange={(event) =>
-                                  updateSet(activeDayIndex, exerciseIndex, setIndex, "done", event.target.checked)
-                                }
-                              />
-                            </td>
-                          </tr>
-                        ))}
+                        {exercise.sets.map((set, setIndex) => {
+                          const isDone = Boolean(set.done);
+                          return (
+                            <tr
+                              key={`${exercise.name}-${setIndex}`}
+                              className={isDone ? "done" : undefined}
+                            >
+                              <td data-label="Set">
+                                <div className="set-cell">
+                                  <span className="set-cell__number">{set.set}</span>
+                                  <button
+                                    aria-pressed={isDone}
+                                    className={classNames("set-cell__done", isDone && "is-done")}
+                                    onClick={() =>
+                                      updateSet(activeDayIndex, exerciseIndex, setIndex, "done", !isDone)
+                                    }
+                                    title={isDone ? "Mark set incomplete" : "Mark set complete"}
+                                    type="button"
+                                  >
+                                    <span aria-hidden="true" className="set-cell__done-icon">
+                                      {isDone ? "✓" : ""}
+                                    </span>
+                                    <span aria-hidden="true" className="set-cell__done-label">
+                                      Done
+                                    </span>
+                                    <span className="sr-only">
+                                      {isDone
+                                        ? `Mark set ${set.set} as not done`
+                                        : `Mark set ${set.set} as done`}
+                                    </span>
+                                  </button>
+                                </div>
+                              </td>
+                              <td data-label="Weight">
+                                <input
+                                  className="in"
+                                  type="text"
+                                  inputMode="decimal"
+                                  placeholder={exercise.suggestedWeight || "lbs"}
+                                  value={set.weight}
+                                  onChange={(event) =>
+                                    updateSet(activeDayIndex, exerciseIndex, setIndex, "weight", event.target.value)
+                                  }
+                                />
+                              </td>
+                              <td data-label={metricLabel}>
+                                <input
+                                  className="in"
+                                  type="text"
+                                  inputMode="numeric"
+                                  placeholder={exercise.type === "seconds" ? "sec" : "reps"}
+                                  value={set.repsOrSec}
+                                  onChange={(event) =>
+                                    updateSet(activeDayIndex, exerciseIndex, setIndex, "repsOrSec", event.target.value)
+                                  }
+                                />
+                              </td>
+                              <td data-label="RPE">
+                                <select
+                                  className="in"
+                                  value={set.rpe}
+                                  onChange={(event) =>
+                                    updateSet(activeDayIndex, exerciseIndex, setIndex, "rpe", event.target.value)
+                                  }
+                                >
+                                  <option value="">--</option>
+                                  <option value="5">5</option>
+                                  <option value="6">6</option>
+                                  <option value="7">7</option>
+                                  <option value="8">8</option>
+                                </select>
+                              </td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
-                    </table>
+                      </table>
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>
-        <div className="card">
-          <h2>How to Use (Beginner-friendly)</h2>
-          <div className="tip">
-            <p>
-              <strong>RPE ~6</strong> = finish each set like you could do ~4 more reps. No straining or holding your breath.
-            </p>
-            <ul>
-              <li>
-                <strong>1)</strong> Pick your day (Day 1 / Day 2 / Day 3).
-              </li>
-              <li>
-                <strong>2)</strong> For each exercise, fill in <em>weight</em>, <em>reps</em> (or seconds), and optionally your
-                <em> RPE</em>.
-              </li>
-              <li>
-                <strong>3)</strong> Check the box ✅ when a set is done. Data saves automatically.
-              </li>
-              <li>
-                <strong>4)</strong> Tap <em>Print</em> to save a PDF, or <em>Export CSV</em> to download your data.
-              </li>
-            </ul>
-          </div>
-          <div className="tip" style={{ marginTop: "8px" }}>
-            <p>
-              <strong>Weekly Progress:</strong> If a weight feels easy with smooth form, add 1–2 reps next time or a small weight
-              increase (+2.5–5 lb). If anything hurts or feels “throbby,” rest more or go lighter.
-            </p>
-            <p style={{ marginTop: "8px" }}>
-              <strong>Template:</strong> {week.templateTitle} — {week.description}
-            </p>
-          </div>
+        <div className="card guide-card">
+          <h2>Quick tips</h2>
+          <ul className="guide-list">
+            <li>Pick a day, log your sets, and check them off as you go.</li>
+            <li>Use the Share button 📤 to send the week anywhere.</li>
+            <li>Keep reps smooth with 3–4 in the tank—then load up next time.</li>
+          </ul>
         </div>
       </div>
     </div>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,0 +1,369 @@
+import Link from "next/link";
+import { ObjectId, type Filter } from "mongodb";
+
+import { getDb } from "@/lib/mongodb";
+import {
+  dedupeWeeksByStart,
+  serializeWeek,
+  type DayEntry,
+  type WeekDocument
+} from "@/lib/week";
+
+import type { WeekListEntry } from "@/app/workouts/types";
+
+import { ProgressDashboard } from "./progress-dashboard";
+import type {
+  ProgressData,
+  ProgressDayAverage,
+  ProgressDayDetail,
+  ProgressTotals,
+  ProgressWeek
+} from "./types";
+
+export const dynamic = "force-dynamic";
+
+function buildUserFilter(userId?: string | null): Filter<WeekDocument> {
+  if (!userId) {
+    return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+  }
+
+  const trimmed = userId.trim();
+
+  if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+    return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+  }
+
+  if (!ObjectId.isValid(trimmed)) {
+    throw new Error("Invalid user id");
+  }
+
+  return { userId: new ObjectId(trimmed) };
+}
+
+async function fetchWeeks(userId?: string | null): Promise<WeekListEntry[]> {
+  const db = await getDb();
+  const collection = db.collection<WeekDocument>("weeks");
+  const documents = await collection
+    .find(buildUserFilter(userId), { sort: { createdAt: -1 } })
+    .toArray();
+
+  const mapped = documents.map((doc) => {
+    const serialized = serializeWeek(doc);
+    return {
+      ...serialized,
+      status: doc.status,
+      archivedAt: doc.archivedAt ? doc.archivedAt.toISOString() : null
+    } satisfies WeekListEntry;
+  });
+
+  return dedupeWeeksByStart(mapped);
+}
+
+function countDaySets(day: DayEntry) {
+  return day.exercises.reduce(
+    (acc, exercise) => {
+      const completedSets = exercise.sets.filter((set) => Boolean(set.done)).length;
+      acc.completed += completedSets;
+      acc.total += exercise.sets.length;
+      return acc;
+    },
+    { completed: 0, total: 0 }
+  );
+}
+
+function formatWeekLabel(weekOf: string) {
+  const baseDate = new Date(`${weekOf}T00:00:00.000Z`);
+  const short = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC"
+  }).format(baseDate);
+  const long = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeZone: "UTC"
+  }).format(baseDate);
+
+  return { label: short, longLabel: `Week of ${long}` };
+}
+
+function buildProgressData(weeks: WeekListEntry[]): ProgressData {
+  const normalizedWeeks = dedupeWeeksByStart(weeks);
+
+  if (normalizedWeeks.length === 0) {
+    return {
+      weeks: [],
+      totals: {
+        completed: 0,
+        total: 0,
+        weekCount: 0,
+        dayCount: 0,
+        averageCompletion: 0
+      },
+      dayAverages: [],
+      dayDetails: [],
+      highlightWeekId: null,
+      latestWeekId: null,
+      currentStreak: 0
+    };
+  }
+
+  const chronological = [...normalizedWeeks].sort((a, b) => {
+    return new Date(a.weekOf).getTime() - new Date(b.weekOf).getTime();
+  });
+
+  const fullDateFormatter = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "full",
+    timeZone: "UTC"
+  });
+  const weekdayFormatter = new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    timeZone: "UTC"
+  });
+  const dayNumberFormatter = new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    timeZone: "UTC"
+  });
+
+  const dayDetails: ProgressDayDetail[] = [];
+
+  const progressWeeks: ProgressWeek[] = chronological.map((week) => {
+    const weekStart = new Date(`${week.weekOf}T00:00:00.000Z`);
+
+    const daySummaries = week.days.map((day, index) => {
+      const dayDate = new Date(weekStart);
+      dayDate.setUTCDate(weekStart.getUTCDate() + index);
+      const { completed, total } = countDaySets(day);
+      const isoDate = dayDate.toISOString().substring(0, 10);
+      const dateLabel = fullDateFormatter.format(dayDate);
+      const weekdayLabel = weekdayFormatter.format(dayDate);
+      const dayNumberLabel = dayNumberFormatter.format(dayDate);
+      const focusId = `${week.id}:${day.id}`;
+
+      const exercises = day.exercises.map((exercise, exerciseIndex) => {
+        const exerciseCompleted = exercise.sets.filter((set) => Boolean(set.done)).length;
+        return {
+          id: `${focusId}:${exerciseIndex}`,
+          name: exercise.name,
+          target: exercise.target,
+          completed: exerciseCompleted,
+          total: exercise.sets.length
+        };
+      });
+
+      const completionRate = total > 0 ? completed / total : 0;
+
+      dayDetails.push({
+        id: focusId,
+        weekId: week.id,
+        isoDate,
+        dateLabel,
+        weekdayLabel,
+        dayNumberLabel,
+        name: day.name,
+        shortName: day.shortName,
+        completed,
+        total,
+        completionRate,
+        exercises
+      });
+
+      return {
+        id: day.id,
+        name: day.name,
+        shortName: day.shortName,
+        completed,
+        total,
+        completionRate,
+        isoDate,
+        dateLabel,
+        weekdayLabel,
+        focusId
+      };
+    });
+
+    const completed = daySummaries.reduce((acc, day) => acc + day.completed, 0);
+    const total = daySummaries.reduce((acc, day) => acc + day.total, 0);
+    const { label, longLabel } = formatWeekLabel(week.weekOf);
+
+    return {
+      id: week.id,
+      weekOf: week.weekOf,
+      label,
+      longLabel,
+      updatedAt: week.updatedAt,
+      templateTitle: week.templateTitle,
+      status: week.status,
+      completed,
+      total,
+      completionRate: total > 0 ? completed / total : 0,
+      days: daySummaries
+    } satisfies ProgressWeek;
+  });
+
+  const totals: ProgressTotals = progressWeeks.reduce(
+    (acc, week) => {
+      acc.completed += week.completed;
+      acc.total += week.total;
+      acc.dayCount += week.days.filter((day) => day.completed > 0).length;
+      return acc;
+    },
+    {
+      completed: 0,
+      total: 0,
+      weekCount: progressWeeks.length,
+      dayCount: 0,
+      averageCompletion: 0
+    }
+  );
+
+  totals.averageCompletion = totals.total > 0 ? totals.completed / totals.total : 0;
+
+  const buckets = new Map<string, ProgressDayAverage>();
+
+  progressWeeks.forEach((week) => {
+    week.days.forEach((day, index) => {
+      const key = `${index}-${day.name}`;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.completed += day.completed;
+        existing.total += day.total;
+      } else {
+        buckets.set(key, {
+          key,
+          label: day.name,
+          completed: day.completed,
+          total: day.total,
+          completionRate: 0,
+          index
+        });
+      }
+    });
+  });
+
+  const dayAverages: ProgressDayAverage[] = Array.from(buckets.values())
+    .map((bucket) => ({
+      ...bucket,
+      completionRate: bucket.total > 0 ? bucket.completed / bucket.total : 0
+    }))
+    .sort((a, b) => a.index - b.index);
+
+  const highlightWeek = [...progressWeeks]
+    .sort((a, b) => {
+      const rateDiff = b.completionRate - a.completionRate;
+      if (rateDiff !== 0) {
+        return rateDiff;
+      }
+      return new Date(b.weekOf).getTime() - new Date(a.weekOf).getTime();
+    })
+    .at(0);
+
+  const latestWeek = progressWeeks.at(-1) ?? null;
+
+  let streak = 0;
+  for (let index = progressWeeks.length - 1; index >= 0; index -= 1) {
+    const week = progressWeeks[index];
+    if (week.completed > 0) {
+      streak += 1;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    weeks: progressWeeks,
+    totals,
+    dayAverages,
+    dayDetails,
+    highlightWeekId: highlightWeek?.id ?? null,
+    latestWeekId: latestWeek?.id ?? null,
+    currentStreak: streak
+  };
+}
+
+type ProgressPageProps = {
+  searchParams?: {
+    userId?: string;
+  };
+};
+
+export default async function ProgressPage({ searchParams }: ProgressPageProps) {
+  const requestedUserId = searchParams?.userId ?? null;
+  const normalizedUserId = requestedUserId
+    ? (() => {
+        const trimmed = requestedUserId.trim();
+        if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+          return null;
+        }
+        return trimmed;
+      })()
+    : null;
+  let weeks: WeekListEntry[] = [];
+  let loadError: string | null = null;
+
+  try {
+    weeks = await fetchWeeks(normalizedUserId);
+  } catch (error) {
+    console.error("Failed to load workouts for progress dashboard", error);
+    if (error instanceof Error && error.message === "Invalid user id") {
+      loadError = "We couldn’t load your history. Please sign in and try again.";
+    } else {
+      loadError = "We couldn’t load your history. Check the database connection and try again.";
+    }
+  }
+
+  const progressData: ProgressData = buildProgressData(weeks);
+  const ownerIdForLinks =
+    loadError === null ? weeks[0]?.userId ?? normalizedUserId ?? null : null;
+  const savedWeeksHref = ownerIdForLinks
+    ? `/workouts?userId=${encodeURIComponent(ownerIdForLinks)}`
+    : "/workouts";
+
+  return (
+    <div className="progress-page">
+      <div className="wrap progress-wrap">
+        <header className="hero hero-compact progress-hero">
+          <div className="hero-heading progress-hero__heading">
+            <p className="eyebrow">Fitmotion Insights</p>
+            <h1>Progress Dashboard</h1>
+            <p className="hero-sub">
+              Visualize completion trends, celebrate streaks, and spot the weeks that delivered the
+              biggest wins.
+            </p>
+          </div>
+          <div className="hero-actions progress-hero__actions">
+            <Link className="btn ghost" href="/">
+              ← Back to tracker
+            </Link>
+            <Link className="btn ghost" href={savedWeeksHref}>
+              Saved weeks
+            </Link>
+          </div>
+        </header>
+
+        {loadError ? (
+          <div className="banner error">
+            <span>{loadError}</span>
+          </div>
+        ) : progressData.weeks.length === 0 ? (
+          <div className="card progress-empty">
+            <h2>No workouts logged yet</h2>
+            <p className="muted">
+              Start a week in the tracker and save your sets to unlock personalized visualizations of
+              your progress.
+            </p>
+            <div className="progress-empty__actions">
+              <Link className="btn" href="/">
+                Go to tracker
+              </Link>
+              <Link className="btn ghost" href="/auth">
+                Log in / Register
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <ProgressDashboard data={progressData} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/progress/progress-dashboard.tsx
+++ b/app/progress/progress-dashboard.tsx
@@ -1,0 +1,929 @@
+"use client";
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+import type { ProgressData, ProgressDayDetail, ProgressWeek } from "./types";
+
+function clampRate(value: number) {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, value));
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(clampRate(value) * 100)}%`;
+}
+
+type LineChartPoint = {
+  label: string;
+  value: number;
+  detail: string;
+};
+
+type LineChartGeometry = {
+  width: number;
+  height: number;
+  path: string;
+  area: string;
+  coords: Array<{ x: number; y: number; point: LineChartPoint }>;
+  baseline: number;
+  paddingX: number;
+  paddingY: number;
+  gridLines: Array<{ y: number; label: string; isZero: boolean }>;
+};
+
+function useLineChartGeometry(points: LineChartPoint[]): LineChartGeometry {
+  return useMemo(() => {
+    const width = 680;
+    const height = 260;
+    const paddingX = 40;
+    const paddingY = 32;
+    const innerWidth = width - paddingX * 2;
+    const innerHeight = height - paddingY * 2;
+    const baseline = height - paddingY;
+    const step = points.length > 1 ? innerWidth / (points.length - 1) : 0;
+
+    const coords = points.map((point, index) => {
+      const value = clampRate(point.value);
+      const x =
+        points.length > 1 ? paddingX + step * index : paddingX + innerWidth / 2;
+      const y = paddingY + innerHeight * (1 - value);
+      return { x, y, point };
+    });
+
+    const path = coords
+      .map((coord, index) => `${index === 0 ? "M" : "L"}${coord.x} ${coord.y}`)
+      .join(" ");
+
+    const area =
+      coords.length > 0
+        ? `${path} L ${coords[coords.length - 1].x} ${baseline} L ${coords[0].x} ${baseline} Z`
+        : "";
+
+    const levelValues = [1, 0.75, 0.5, 0.25, 0];
+    const gridLines = levelValues.map((value) => ({
+      y: paddingY + innerHeight * (1 - value),
+      label: `${Math.round(value * 100)}%`,
+      isZero: value === 0
+    }));
+
+    return {
+      width,
+      height,
+      path,
+      area,
+      coords,
+      baseline,
+      paddingX,
+      paddingY,
+      gridLines
+    } satisfies LineChartGeometry;
+  }, [points]);
+}
+
+function LineChart({ points }: { points: LineChartPoint[] }) {
+  const geometry = useLineChartGeometry(points);
+  const reactId = useId().replace(/:/g, "");
+  const gradientId = `progress-line-${reactId}`;
+  const areaId = `progress-line-area-${reactId}`;
+  const chartId = `progress-line-chart-${reactId}`;
+  const description = points
+    .map((point) => `${point.label} ${point.detail}`)
+    .join("; ");
+
+  return (
+    <div className="progress-line-chart">
+      <svg
+        aria-labelledby={`${chartId}-title ${chartId}-desc`}
+        className="progress-line-chart__svg"
+        role="img"
+        viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+      >
+        <title id={`${chartId}-title`}>Weekly completion trend</title>
+        <desc id={`${chartId}-desc`}>
+          {description || "Completion data will appear after you log workouts."}
+        </desc>
+        <defs>
+          <linearGradient id={gradientId} x1="0%" x2="100%" y1="0%" y2="0%">
+            <stop offset="0%" stopColor="var(--accent)" />
+            <stop offset="100%" stopColor="var(--accent-strong)" />
+          </linearGradient>
+          <linearGradient id={areaId} x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="0%" stopColor="rgba(24, 214, 198, 0.28)" />
+            <stop offset="100%" stopColor="rgba(24, 214, 198, 0.05)" />
+          </linearGradient>
+        </defs>
+        {geometry.gridLines.map((line) => (
+          <g key={line.label}>
+            <line
+              className={`progress-line-chart__grid-line${line.isZero ? " is-zero" : ""}`}
+              x1={geometry.paddingX}
+              x2={geometry.width - geometry.paddingX}
+              y1={line.y}
+              y2={line.y}
+            />
+            <text
+              className="progress-line-chart__axis-label"
+              x={geometry.paddingX - 12}
+              y={line.y + 4}
+            >
+              {line.label}
+            </text>
+          </g>
+        ))}
+        {geometry.area && (
+          <path className="progress-line-chart__area" d={geometry.area} fill={`url(#${areaId})`} />
+        )}
+        {geometry.path && (
+          <path
+            className="progress-line-chart__line"
+            d={geometry.path}
+            fill="none"
+            stroke={`url(#${gradientId})`}
+          />
+        )}
+        {geometry.coords.map(({ x, y, point }) => (
+          <g key={`${point.label}-${x}`}> 
+            <circle className="progress-line-chart__dot" cx={x} cy={y} r={6} />
+            <text className="progress-line-chart__value" x={x} y={y - 12}>
+              {point.detail}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <div className="progress-line-chart__labels" aria-hidden="true">
+        {points.map((point) => (
+          <span key={point.label}>
+            <span className="progress-line-chart__label-value">{point.detail}</span>
+            <span className="progress-line-chart__label-text">{point.label}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type BarChartPoint = {
+  label: string;
+  value: number;
+  detail: string;
+};
+
+type BarChartGeometry = {
+  width: number;
+  height: number;
+  bars: Array<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    point: BarChartPoint;
+  }>;
+  baseline: number;
+  paddingX: number;
+  paddingY: number;
+};
+
+function useBarChartGeometry(points: BarChartPoint[]): BarChartGeometry {
+  return useMemo(() => {
+    const width = 520;
+    const height = 260;
+    const paddingX = 44;
+    const paddingY = 32;
+    const innerWidth = width - paddingX * 2;
+    const innerHeight = height - paddingY * 2;
+    const baseline = height - paddingY;
+    const barStep = points.length > 0 ? innerWidth / points.length : innerWidth;
+    const barWidth = points.length > 0 ? Math.max(26, barStep * 0.55) : innerWidth * 0.6;
+
+    const bars = points.map((point, index) => {
+      const value = clampRate(point.value);
+      const x = paddingX + index * barStep + (barStep - barWidth) / 2;
+      const barHeight = innerHeight * value;
+      const y = baseline - barHeight;
+      return {
+        x,
+        y,
+        width: barWidth,
+        height: barHeight,
+        point
+      };
+    });
+
+    return {
+      width,
+      height,
+      bars,
+      baseline,
+      paddingX,
+      paddingY
+    } satisfies BarChartGeometry;
+  }, [points]);
+}
+
+function BarChart({ points }: { points: BarChartPoint[] }) {
+  const geometry = useBarChartGeometry(points);
+  const reactId = useId().replace(/:/g, "");
+  const gradientId = `progress-bar-${reactId}`;
+  const chartId = `progress-bar-chart-${reactId}`;
+  const description = points
+    .map((point) => `${point.label} ${point.detail}`)
+    .join("; ");
+
+  if (points.length === 0) {
+    return <p className="progress-chart__empty">Log workouts to unlock day-by-day insights.</p>;
+  }
+
+  return (
+    <div className="progress-bar-chart">
+      <svg
+        aria-labelledby={`${chartId}-title ${chartId}-desc`}
+        className="progress-bar-chart__svg"
+        role="img"
+        viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+      >
+        <title id={`${chartId}-title`}>Average completion by training day</title>
+        <desc id={`${chartId}-desc`}>
+          {description || "Day averages will render after workouts are logged."}
+        </desc>
+        <defs>
+          <linearGradient id={gradientId} x1="0%" x2="0%" y1="0%" y2="100%">
+            <stop offset="0%" stopColor="rgba(24, 214, 198, 0.9)" />
+            <stop offset="100%" stopColor="rgba(24, 214, 198, 0.35)" />
+          </linearGradient>
+        </defs>
+        <line
+          className="progress-bar-chart__baseline"
+          x1={geometry.paddingX}
+          x2={geometry.width - geometry.paddingX}
+          y1={geometry.baseline}
+          y2={geometry.baseline}
+        />
+        {geometry.bars.map(({ x, y, width, height, point }) => (
+          <g key={`${point.label}-${x}`}>
+            <rect
+              className="progress-bar-chart__bar"
+              fill={`url(#${gradientId})`}
+              height={Math.max(height, 0)}
+              rx={12}
+              ry={12}
+              width={width}
+              x={x}
+              y={y}
+            />
+            <text className="progress-bar-chart__value" x={x + width / 2} y={y - 10}>
+              {point.detail}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <div className="progress-bar-chart__labels" aria-hidden="true">
+        {points.map((point) => (
+          <span key={point.label}>
+            <span className="progress-bar-chart__label-value">{point.detail}</span>
+            <span className="progress-bar-chart__label-text">{point.label}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type RadialGaugeProps = {
+  value: number;
+  label: string;
+  subLabel: string;
+};
+
+function RadialGauge({ value, label, subLabel }: RadialGaugeProps) {
+  const reactId = useId().replace(/:/g, "");
+  const gradientId = `progress-ring-gradient-${reactId}`;
+  const chartId = `progress-ring-${reactId}`;
+  const clamped = clampRate(value);
+  const radius = 74;
+  const strokeWidth = 13;
+  const center = 90;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - clamped);
+
+  return (
+    <div className="progress-ring">
+      <svg
+        aria-labelledby={`${chartId}-title ${chartId}-desc`}
+        role="img"
+        viewBox={`0 0 ${center * 2} ${center * 2}`}
+      >
+        <title id={`${chartId}-title`}>Week completion</title>
+        <desc id={`${chartId}-desc`}>{label} of sets complete</desc>
+        <defs>
+          <linearGradient id={gradientId} x1="0%" x2="100%" y1="0%" y2="100%">
+            <stop offset="0%" stopColor="var(--accent)" />
+            <stop offset="100%" stopColor="var(--accent-strong)" />
+          </linearGradient>
+        </defs>
+        <circle
+          className="progress-ring__bg"
+          cx={center}
+          cy={center}
+          fill="none"
+          r={radius}
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          className="progress-ring__value"
+          cx={center}
+          cy={center}
+          fill="none"
+          r={radius}
+          stroke={`url(#${gradientId})`}
+          strokeDasharray={`${circumference} ${circumference}`}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+        <text className="progress-ring__label" x={center} y={center - 4}>
+          {label}
+        </text>
+        <text className="progress-ring__sub" x={center} y={center + 18}>
+          {subLabel}
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+function describeDelta(delta: number | null) {
+  if (delta === null) {
+    return { label: "First tracked week", tone: "neutral" as const };
+  }
+
+  const rounded = Math.round(delta * 100);
+
+  if (rounded > 0) {
+    return { label: `▲ ${rounded} pp vs prior week`, tone: "positive" as const };
+  }
+
+  if (rounded < 0) {
+    return { label: `▼ ${Math.abs(rounded)} pp vs prior week`, tone: "negative" as const };
+  }
+
+  return { label: "No change vs prior week", tone: "neutral" as const };
+}
+
+export function ProgressDashboard({ data }: { data: ProgressData }) {
+  const { weeks, totals, dayAverages, dayDetails, highlightWeekId, latestWeekId, currentStreak } = data;
+
+  const fallbackWeekId = weeks.length > 0 ? weeks[weeks.length - 1].id : null;
+  const initialSelectedId = latestWeekId ?? highlightWeekId ?? fallbackWeekId;
+  const [selectedWeekId, setSelectedWeekId] = useState<string | null>(initialSelectedId);
+  const [focusScope, setFocusScope] = useState<"week" | "day">("week");
+  const [selectedDayId, setSelectedDayId] = useState<string | null>(null);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const calendarRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setSelectedWeekId((previous) => {
+      if (previous && weeks.some((week) => week.id === previous)) {
+        return previous;
+      }
+      const fallback = latestWeekId ?? highlightWeekId ?? (weeks.length > 0 ? weeks[weeks.length - 1].id : null);
+      return fallback;
+    });
+  }, [weeks, latestWeekId, highlightWeekId]);
+
+  useEffect(() => {
+    if (!calendarOpen) {
+      return;
+    }
+
+    function handlePointer(event: MouseEvent | TouchEvent) {
+      if (!calendarRef.current) {
+        return;
+      }
+      if (event.target instanceof Node && !calendarRef.current.contains(event.target)) {
+        setCalendarOpen(false);
+      }
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setCalendarOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [calendarOpen]);
+
+  const selectedWeek = useMemo(() => {
+    if (weeks.length === 0) {
+      return null;
+    }
+    return weeks.find((week) => week.id === selectedWeekId) ?? weeks[weeks.length - 1];
+  }, [weeks, selectedWeekId]);
+
+  const selectedWeekIdForDay = selectedWeek?.id ?? null;
+
+  useEffect(() => {
+    if (focusScope !== "day") {
+      return;
+    }
+
+    setSelectedDayId((previous) => {
+      if (previous && dayDetails.some((day) => day.id === previous)) {
+        return previous;
+      }
+
+      const fallbackDay =
+        (selectedWeekIdForDay
+          ? dayDetails.find((day) => day.weekId === selectedWeekIdForDay)
+          : null) ?? dayDetails.at(-1) ?? null;
+
+      return fallbackDay?.id ?? null;
+    });
+  }, [focusScope, dayDetails, selectedWeekIdForDay]);
+
+  const highlightWeek = useMemo(() => {
+    if (!highlightWeekId) {
+      return null;
+    }
+    return weeks.find((week) => week.id === highlightWeekId) ?? null;
+  }, [highlightWeekId, weeks]);
+
+  const selectedDay = useMemo(() => {
+    if (!selectedDayId) {
+      return null;
+    }
+    return dayDetails.find((day) => day.id === selectedDayId) ?? null;
+  }, [selectedDayId, dayDetails]);
+
+  const focusWeekIdForDays = selectedDay?.weekId ?? selectedWeekIdForDay;
+
+  const focusWeekForDays = useMemo(() => {
+    if (!focusWeekIdForDays) {
+      return null;
+    }
+    return weeks.find((week) => week.id === focusWeekIdForDays) ?? null;
+  }, [focusWeekIdForDays, weeks]);
+
+  const focusWeekDays = useMemo(() => {
+    if (!focusWeekIdForDays) {
+      return [];
+    }
+    return dayDetails
+      .filter((day) => day.weekId === focusWeekIdForDays)
+      .sort((a, b) => new Date(a.isoDate).getTime() - new Date(b.isoDate).getTime());
+  }, [dayDetails, focusWeekIdForDays]);
+
+  const calendarMonths = useMemo(() => {
+    if (weeks.length === 0) {
+      return [];
+    }
+
+    const monthFormatter = new Intl.DateTimeFormat("en-US", {
+      month: "long",
+      year: "numeric",
+      timeZone: "UTC"
+    });
+
+    const sortedWeeks = [...weeks].sort((a, b) => {
+      return new Date(b.weekOf).getTime() - new Date(a.weekOf).getTime();
+    });
+
+    const monthMap = new Map<
+      string,
+      {
+        key: string;
+        label: string;
+        time: number;
+        weeks: Array<{
+          week: ProgressWeek;
+          time: number;
+          days: ProgressDayDetail[];
+        }>;
+      }
+    >();
+
+    sortedWeeks.forEach((week) => {
+      const baseDate = new Date(`${week.weekOf}T00:00:00.000Z`);
+      const key = `${baseDate.getUTCFullYear()}-${String(baseDate.getUTCMonth()).padStart(2, "0")}`;
+      const monthTime = Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), 1);
+      const daysForWeek = dayDetails
+        .filter((day) => day.weekId === week.id)
+        .sort((a, b) => new Date(a.isoDate).getTime() - new Date(b.isoDate).getTime());
+
+      const entry = monthMap.get(key);
+      if (entry) {
+        entry.weeks.push({ week, time: baseDate.getTime(), days: daysForWeek });
+      } else {
+        monthMap.set(key, {
+          key,
+          label: monthFormatter.format(baseDate),
+          time: monthTime,
+          weeks: [{ week, time: baseDate.getTime(), days: daysForWeek }]
+        });
+      }
+    });
+
+    return Array.from(monthMap.values())
+      .sort((a, b) => b.time - a.time)
+      .map((month) => ({
+        key: month.key,
+        label: month.label,
+        weeks: month.weeks.sort((a, b) => b.time - a.time)
+      }));
+  }, [weeks, dayDetails]);
+
+  const weeklyPoints: LineChartPoint[] = useMemo(
+    () =>
+      weeks.map((week) => ({
+        label: week.label,
+        value: week.completionRate,
+        detail: formatPercent(week.completionRate)
+      })),
+    [weeks]
+  );
+
+  const dayPoints: BarChartPoint[] = useMemo(
+    () =>
+      dayAverages.map((day) => ({
+        label: day.label,
+        value: day.completionRate,
+        detail: formatPercent(day.completionRate)
+      })),
+    [dayAverages]
+  );
+
+  const timelineWeeks = useMemo(() => [...weeks].reverse(), [weeks]);
+  const weekOptions = useMemo(() => [...weeks].reverse(), [weeks]);
+
+  if (weeks.length === 0 || !selectedWeek) {
+    return null;
+  }
+
+  const selectedIndex = weeks.findIndex((week) => week.id === selectedWeek.id);
+  const previousWeek: ProgressWeek | null = selectedIndex > 0 ? weeks[selectedIndex - 1] : null;
+  const completionDelta = previousWeek ? selectedWeek.completionRate - previousWeek.completionRate : null;
+  const deltaDescriptor = describeDelta(completionDelta);
+
+  const totalCompletionPercent = totals.total > 0 ? Math.round((totals.completed / totals.total) * 100) : 0;
+  const selectedCompletionPercent = Math.round(selectedWeek.completionRate * 100);
+  const highlightPercent = highlightWeek ? Math.round(highlightWeek.completionRate * 100) : null;
+  const selectedDayPercent = selectedDay ? Math.round(selectedDay.completionRate * 100) : 0;
+  const focusGaugeLabel = focusScope === "week" ? `${selectedCompletionPercent}%` : `${selectedDayPercent}%`;
+  const focusGaugeValue = focusScope === "week" ? selectedWeek.completionRate : selectedDay?.completionRate ?? 0;
+  const focusEyebrow = focusScope === "week" ? "Focus week" : "Focus day";
+  const focusTitle = focusScope === "week" ? selectedWeek.longLabel : selectedDay?.dateLabel ?? "Select a day";
+  const focusMeta =
+    focusScope === "week"
+      ? `${selectedWeek.templateTitle} • ${selectedWeek.completed}/${selectedWeek.total} sets complete`
+      : selectedDay
+      ? `${selectedDay.name} • ${selectedDay.completed}/${selectedDay.total} sets complete`
+      : "Select a day from the calendar to inspect detailed stats.";
+  const focusBadge =
+    focusScope === "week"
+      ? (
+          <span className={`progress-delta progress-delta--${deltaDescriptor.tone}`}>
+            {deltaDescriptor.label}
+          </span>
+        )
+      : selectedDay && focusWeekForDays
+      ? <span className="progress-focus__chip">Part of {focusWeekForDays.longLabel}</span>
+      : null;
+  const calendarLabel = focusScope === "week" ? "Choose a week to inspect" : "Choose a day to inspect";
+
+  return (
+    <div className="progress-dashboard">
+      <section className="progress-summary-grid" aria-label="Progress summary">
+        <article className="progress-summary-card">
+          <p className="progress-summary-label">Sets logged</p>
+          <p className="progress-summary-value">{totals.completed}</p>
+          <p className="progress-summary-sub">of {totals.total} total sets</p>
+        </article>
+        <article className="progress-summary-card">
+          <p className="progress-summary-label">Average completion</p>
+          <p className="progress-summary-value">{totalCompletionPercent}%</p>
+          <p className="progress-summary-sub">
+            {totals.weekCount} week{totals.weekCount === 1 ? "" : "s"} tracked • {totals.dayCount} day
+            {totals.dayCount === 1 ? "" : "s"} logged
+          </p>
+        </article>
+        <article className="progress-summary-card progress-summary-card--accent">
+          <p className="progress-summary-label">Current streak</p>
+          <p className="progress-summary-value">{currentStreak}</p>
+          <p className="progress-summary-sub">
+            week{currentStreak === 1 ? "" : "s"} in a row with completed sets
+          </p>
+          {highlightWeek && (
+            <span className="progress-summary-chip">
+              Best week • {highlightWeek.longLabel} · {highlightPercent}% complete
+            </span>
+          )}
+        </article>
+      </section>
+
+      <div className="progress-grid">
+        <article className="progress-card" aria-label="Weekly completion chart">
+          <div className="progress-card__header">
+            <div>
+              <p className="eyebrow">Trend</p>
+              <h2>Weekly completion</h2>
+            </div>
+            <span className="progress-card__meta">
+              {weeklyPoints.length} week{weeklyPoints.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <LineChart points={weeklyPoints} />
+        </article>
+
+        <article className="progress-card" aria-label="Average completion by day">
+          <div className="progress-card__header">
+            <div>
+              <p className="eyebrow">Consistency</p>
+              <h2>Day-by-day average</h2>
+            </div>
+            <span className="progress-card__meta">
+              {totals.dayCount} logged day{totals.dayCount === 1 ? "" : "s"}
+            </span>
+          </div>
+          <BarChart points={dayPoints} />
+        </article>
+
+        <article className="progress-card progress-card--full" aria-label="Focus insights">
+          <div className="progress-focus">
+            <div className="progress-focus__top">
+              <div className="progress-focus__intro">
+                <p className="eyebrow">{focusEyebrow}</p>
+                <h2>{focusTitle}</h2>
+                <p className="progress-focus__meta">{focusMeta}</p>
+                {focusBadge}
+              </div>
+              <RadialGauge label={focusGaugeLabel} subLabel="complete" value={focusGaugeValue} />
+            </div>
+
+            <div className="progress-focus__controls">
+              <div className="progress-segmented" role="radiogroup" aria-label="Focus view">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={focusScope === "week"}
+                  className={`progress-segmented__option${focusScope === "week" ? " is-active" : ""}`}
+                  onClick={() => {
+                    setFocusScope("week");
+                    setCalendarOpen(false);
+                  }}
+                >
+                  Week
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={focusScope === "day"}
+                  className={`progress-segmented__option${focusScope === "day" ? " is-active" : ""}`}
+                  onClick={() => {
+                    setFocusScope("day");
+                    setCalendarOpen(false);
+                  }}
+                >
+                  Day
+                </button>
+              </div>
+              <div className="progress-calendar-toggle" ref={calendarRef}>
+                <button
+                  type="button"
+                  className={`progress-calendar-toggle__button${calendarOpen ? " is-open" : ""}`}
+                  aria-expanded={calendarOpen}
+                  aria-haspopup="dialog"
+                  onClick={() => setCalendarOpen((open) => !open)}
+                >
+                  <span>Calendar</span>
+                  <svg
+                    aria-hidden="true"
+                    focusable="false"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path d="M5.25 7.5L10 12.25L14.75 7.5H5.25Z" fill="currentColor" />
+                  </svg>
+                </button>
+                {calendarOpen && (
+                  <div aria-label={calendarLabel} className="progress-calendar" role="dialog">
+                    {calendarMonths.length === 0 ? (
+                      <p className="progress-calendar__empty">No history yet.</p>
+                    ) : (
+                      calendarMonths.map((month) => (
+                        <div className="progress-calendar__month" key={month.key}>
+                          <p className="progress-calendar__month-label">{month.label}</p>
+                          <div className="progress-calendar__week-grid">
+                            {month.weeks.map(({ week, days }) => {
+                              const weekPercent = Math.round(week.completionRate * 100);
+                              const isWeekActive = focusScope === "week" && week.id === selectedWeek.id;
+                              return (
+                                <div className="progress-calendar__week" key={week.id}>
+                                  <button
+                                    type="button"
+                                    className={`progress-calendar__week-button${isWeekActive ? " is-active" : ""}`}
+                                    onClick={() => {
+                                      setSelectedWeekId(week.id);
+                                      setFocusScope("week");
+                                      setCalendarOpen(false);
+                                    }}
+                                  >
+                                    <span className="progress-calendar__week-title">{week.longLabel}</span>
+                                    <span className="progress-calendar__week-meta">{weekPercent}%</span>
+                                  </button>
+                                  {focusScope === "day" && days.length > 0 && (
+                                    <div className="progress-calendar__day-grid">
+                                      {days.map((day) => {
+                                        const percent = Math.round(day.completionRate * 100);
+                                        const isDayActive = selectedDay?.id === day.id;
+                                        return (
+                                          <button
+                                            type="button"
+                                            className={`progress-calendar__day-button${isDayActive ? " is-active" : ""}`}
+                                            key={day.id}
+                                            onClick={() => {
+                                              setSelectedWeekId(day.weekId);
+                                              setSelectedDayId(day.id);
+                                              setFocusScope("day");
+                                              setCalendarOpen(false);
+                                            }}
+                                          >
+                                            <span className="progress-calendar__day-weekday">{day.weekdayLabel}</span>
+                                            <span className="progress-calendar__day-number">{day.dayNumberLabel}</span>
+                                            <span className="progress-calendar__day-percent">{percent}%</span>
+                                          </button>
+                                        );
+                                      })}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {focusScope === "week" ? (
+              <>
+                <div
+                  aria-label="Select a week to inspect"
+                  className="progress-week-picker"
+                  role="listbox"
+                  tabIndex={0}
+                >
+                  {weekOptions.map((week) => {
+                    const percent = Math.round(week.completionRate * 100);
+                    const isSelected = week.id === selectedWeek.id;
+                    return (
+                      <button
+                        aria-selected={isSelected}
+                        className="progress-week-picker__option"
+                        key={week.id}
+                        onClick={() => setSelectedWeekId(week.id)}
+                        role="option"
+                        type="button"
+                      >
+                        <strong>{week.label}</strong>
+                        <span>{percent}%</span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <ul className="progress-day-list">
+                  {selectedWeek.days.map((day) => {
+                    const rate = day.total > 0 ? day.completed / day.total : 0;
+                    const percent = Math.round(rate * 100);
+                    return (
+                      <li className="progress-day" key={day.focusId}>
+                        <div className="progress-day__heading">
+                          <div className="progress-day__title">
+                            <span>{day.name}</span>
+                            <span className="progress-day__chip">
+                              {day.completed}/{day.total} set{day.total === 1 ? "" : "s"}
+                            </span>
+                          </div>
+                          <span className="progress-day__percent">{percent}%</span>
+                        </div>
+                        <div className="progress-bar" aria-hidden="true">
+                          <div className="progress-bar__value" style={{ width: `${percent}%` }} />
+                        </div>
+                        <span className="progress-day__meta">
+                          {day.weekdayLabel} • {percent}% complete
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            ) : (
+              <>
+                <div
+                  className="progress-day-picker"
+                  role="tablist"
+                  aria-label={focusWeekForDays ? `Days logged for ${focusWeekForDays.longLabel}` : "Days logged"}
+                >
+                  {focusWeekDays.map((day) => {
+                    const percent = Math.round(day.completionRate * 100);
+                    const isActive = selectedDay?.id === day.id;
+                    return (
+                      <button
+                        aria-selected={isActive}
+                        className={`progress-day-picker__option${isActive ? " is-active" : ""}`}
+                        key={day.id}
+                        onClick={() => {
+                          setSelectedDayId(day.id);
+                          setFocusScope("day");
+                        }}
+                        role="tab"
+                        type="button"
+                      >
+                        <span className="progress-day-picker__label">{day.shortName}</span>
+                        <span className="progress-day-picker__meta">{percent}%</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                {selectedDay ? (
+                  <ul className="progress-exercise-list">
+                    {selectedDay.exercises.map((exercise) => {
+                      const percent =
+                        exercise.total > 0 ? Math.round((exercise.completed / exercise.total) * 100) : 0;
+                      return (
+                        <li className="progress-exercise" key={exercise.id}>
+                          <div className="progress-exercise__heading">
+                            <div className="progress-exercise__title">
+                              <span>{exercise.name}</span>
+                              <span className="progress-exercise__target">{exercise.target}</span>
+                            </div>
+                            <span className="progress-exercise__percent">{percent}%</span>
+                          </div>
+                          <div className="progress-bar" aria-hidden="true">
+                            <div className="progress-bar__value" style={{ width: `${percent}%` }} />
+                          </div>
+                          <span className="progress-exercise__meta">
+                            {exercise.completed}/{exercise.total} set{exercise.total === 1 ? "" : "s"} complete
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <div className="progress-focus__empty">
+                    Select a day from the calendar to explore exercise-level stats.
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </article>
+
+        <article className="progress-card progress-card--full" aria-label="Week timeline">
+          <div className="progress-card__header">
+            <div>
+              <p className="eyebrow">History</p>
+              <h2>Week timeline</h2>
+            </div>
+          </div>
+          <ul className="progress-timeline">
+            {timelineWeeks.map((week) => {
+              const percent = Math.round(week.completionRate * 100);
+              return (
+                <li className="progress-timeline__item" key={week.id}>
+                  <div className="progress-timeline__header">
+                    <span className="progress-timeline__title">{week.longLabel}</span>
+                    <span className="progress-timeline__percent">{percent}%</span>
+                  </div>
+                  <div className="progress-bar" aria-hidden="true">
+                    <div className="progress-bar__value" style={{ width: `${percent}%` }} />
+                  </div>
+                  <div className="progress-timeline__meta">
+                    <span>{week.templateTitle}</span>
+                    <span>
+                      {week.completed}/{week.total} set{week.total === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/app/progress/types.ts
+++ b/app/progress/types.ts
@@ -1,0 +1,76 @@
+export type ProgressExerciseSummary = {
+  id: string;
+  name: string;
+  target: string;
+  completed: number;
+  total: number;
+};
+
+export type ProgressDay = {
+  id: string;
+  name: string;
+  shortName: string;
+  completed: number;
+  total: number;
+  completionRate: number;
+  isoDate: string;
+  dateLabel: string;
+  weekdayLabel: string;
+  focusId: string;
+};
+
+export type ProgressWeek = {
+  id: string;
+  weekOf: string;
+  label: string;
+  longLabel: string;
+  updatedAt: string;
+  templateTitle: string;
+  status: "active" | "archived";
+  completed: number;
+  total: number;
+  completionRate: number;
+  days: ProgressDay[];
+};
+
+export type ProgressDayDetail = {
+  id: string;
+  weekId: string;
+  isoDate: string;
+  dateLabel: string;
+  weekdayLabel: string;
+  dayNumberLabel: string;
+  name: string;
+  shortName: string;
+  completed: number;
+  total: number;
+  completionRate: number;
+  exercises: ProgressExerciseSummary[];
+};
+
+export type ProgressDayAverage = {
+  key: string;
+  label: string;
+  completed: number;
+  total: number;
+  completionRate: number;
+  index: number;
+};
+
+export type ProgressTotals = {
+  completed: number;
+  total: number;
+  weekCount: number;
+  dayCount: number;
+  averageCompletion: number;
+};
+
+export type ProgressData = {
+  weeks: ProgressWeek[];
+  totals: ProgressTotals;
+  dayAverages: ProgressDayAverage[];
+  dayDetails: ProgressDayDetail[];
+  highlightWeekId: string | null;
+  latestWeekId: string | null;
+  currentStreak: number;
+};

--- a/app/workouts/archive-viewer.tsx
+++ b/app/workouts/archive-viewer.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { DayEntry } from "@/lib/week";
+
+import type { WeekListEntry } from "./types";
+
+type ArchiveViewerProps = {
+  weeks: WeekListEntry[];
+};
+
+function cx(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+function formatDateTime(iso: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short"
+  }).format(new Date(iso));
+}
+
+function formatWeekOf(weekOf: string) {
+  const date = new Date(`${weekOf}T00:00:00.000Z`);
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeZone: "UTC"
+  }).format(date);
+}
+
+function countDaySets(day: DayEntry) {
+  return day.exercises.reduce(
+    (acc, exercise) => {
+      acc.total += exercise.sets.length;
+      acc.completed += exercise.sets.filter((set) => Boolean(set.done)).length;
+      return acc;
+    },
+    { completed: 0, total: 0 }
+  );
+}
+
+function countWeekSets(week: WeekListEntry) {
+  return week.days.reduce(
+    (acc, day) => {
+      const { completed, total } = countDaySets(day);
+      acc.completed += completed;
+      acc.total += total;
+      if (completed > 0) {
+        acc.dayCount += 1;
+      }
+      return acc;
+    },
+    { completed: 0, total: 0, dayCount: 0 }
+  );
+}
+
+function describeStatus(week: WeekListEntry) {
+  if (week.status === "active") {
+    return "Active week";
+  }
+
+  if (week.archivedAt) {
+    return `Archived · ${formatDateTime(week.archivedAt)}`;
+  }
+
+  return "Archived";
+}
+
+export function ArchiveViewer({ weeks }: ArchiveViewerProps) {
+  const defaultWeekId = useMemo(() => {
+    const activeWeek = weeks.find((week) => week.status === "active");
+    return activeWeek?.id ?? weeks[0]?.id ?? null;
+  }, [weeks]);
+
+  const [selectedWeekId, setSelectedWeekId] = useState<string | null>(defaultWeekId);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setSelectedWeekId((previous) => {
+      if (previous && weeks.some((week) => week.id === previous)) {
+        return previous;
+      }
+      return defaultWeekId;
+    });
+  }, [weeks, defaultWeekId]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    function handlePointer(event: MouseEvent | TouchEvent) {
+      if (!menuRef.current) {
+        return;
+      }
+      if (event.target instanceof Node && !menuRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    }
+
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [menuOpen]);
+
+  const selectedWeek = useMemo(
+    () => weeks.find((week) => week.id === selectedWeekId) ?? weeks[0] ?? null,
+    [weeks, selectedWeekId]
+  );
+
+  if (!selectedWeek) {
+    return null;
+  }
+
+  const { completed, total, dayCount } = countWeekSets(selectedWeek);
+  const formattedWeek = formatWeekOf(selectedWeek.weekOf);
+  const selectedIndex = weeks.findIndex((week) => week.id === selectedWeek.id);
+  const hasMultipleWeeks = weeks.length > 1;
+
+  return (
+    <div className="archive-viewer">
+      <div className="archive-toolbar">
+        <div className="archive-picker" ref={menuRef}>
+          <button
+            aria-controls="archive-week-menu"
+            aria-expanded={menuOpen && hasMultipleWeeks}
+            aria-haspopup="listbox"
+            className="archive-picker__button"
+            disabled={!hasMultipleWeeks}
+            onClick={() => {
+              if (hasMultipleWeeks) {
+                setMenuOpen((open) => !open);
+              }
+            }}
+            type="button"
+          >
+            <span className="archive-picker__text">
+              <span className="archive-picker__eyebrow">
+                {selectedWeek.status === "active" ? "Active week" : "Saved week"}
+              </span>
+              <span className="archive-picker__value">Week of {formattedWeek}</span>
+            </span>
+            {hasMultipleWeeks && (
+              <svg
+                aria-hidden="true"
+                className={cx("archive-picker__icon", menuOpen && "open")}
+                focusable="false"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M5.25 7.5L10 12.25L14.75 7.5H5.25Z" fill="currentColor" />
+              </svg>
+            )}
+          </button>
+          {menuOpen && hasMultipleWeeks && (
+            <ul
+              aria-label="Saved weeks"
+              className="archive-picker__menu"
+              id="archive-week-menu"
+              role="listbox"
+            >
+              {weeks.map((week) => {
+                const isSelected = week.id === selectedWeek.id;
+                return (
+                  <li key={week.id}>
+                    <button
+                      aria-selected={isSelected}
+                      className={cx("archive-picker__option", isSelected && "selected")}
+                      onClick={() => {
+                        setSelectedWeekId(week.id);
+                        setMenuOpen(false);
+                      }}
+                      role="option"
+                      type="button"
+                    >
+                      <span className="archive-picker__option-week">
+                        Week of {formatWeekOf(week.weekOf)}
+                      </span>
+                      <span className="archive-picker__option-meta">{describeStatus(week)}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+        <p className="archive-count" role="status">
+          Viewing {selectedIndex + 1} of {weeks.length} saved week{weeks.length === 1 ? "" : "s"}.
+        </p>
+      </div>
+
+      <article className="card workout-card">
+        <div className="workout-header">
+          <div>
+            <h2>Week of {formattedWeek}</h2>
+            <ul className="workout-summary-grid">
+              <li className="summary-item">
+                <span className="summary-label">Days logged</span>
+                <span className="summary-value-row">
+                  <span className="summary-value">{dayCount}</span>
+                  <span className="summary-subvalue">
+                    logged day{dayCount === 1 ? "" : "s"}
+                  </span>
+                </span>
+              </li>
+              <li className="summary-item">
+                <span className="summary-label">Sets complete</span>
+                <span className="summary-value-row">
+                  <span className="summary-value">{completed}</span>
+                  <span className="summary-subvalue">of {total}</span>
+                </span>
+              </li>
+              <li className="summary-item">
+                <span className="summary-label">Last updated</span>
+                <span className="summary-value summary-value-compact">
+                  {formatDateTime(selectedWeek.updatedAt)}
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div className="workout-tags">
+            <span className="pill template-pill" title={selectedWeek.description}>
+              {selectedWeek.templateTitle}
+            </span>
+            <span
+              className={cx(
+                "pill",
+                selectedWeek.status === "active" ? "pill-active" : "pill-archived"
+              )}
+            >
+              {describeStatus(selectedWeek)}
+            </span>
+          </div>
+        </div>
+
+        <div
+          aria-label={`Days logged for the week of ${formattedWeek}`}
+          className="day-carousel"
+        >
+          <div className="day-track">
+            {selectedWeek.days.map((day) => {
+              const { completed: dayCompleted, total: dayTotal } = countDaySets(day);
+
+              return (
+                <section className="day-card" key={day.id}>
+                  <div className="day-header">
+                    <h3>{day.name}</h3>
+                    <div className="day-meta">
+                      {day.shortName} • {dayCompleted}/{dayTotal} sets complete
+                    </div>
+                  </div>
+
+                  {day.exercises.map((exercise) => {
+                    const exerciseKey = `${day.id}-${exercise.name}`;
+                    const exerciseCompleted = exercise.sets.filter((set) => Boolean(set.done)).length;
+
+                    return (
+                      <div className="exercise-summary" key={exerciseKey}>
+                        <div className="exercise-summary-title">
+                          <span>{exercise.name}</span>
+                          <span className="muted small">({exercise.target})</span>
+                        </div>
+                        {exercise.suggestedWeight && (
+                          <div className="exercise-summary-suggested">
+                            Suggested: {exercise.suggestedWeight}
+                          </div>
+                        )}
+                        <div className="exercise-summary-how">{exercise.how}</div>
+                        <div className="exercise-table-wrap">
+                          <table className="exercise-table">
+                            <thead>
+                              <tr>
+                                <th scope="col">Set</th>
+                                <th scope="col">Weight</th>
+                                <th scope="col">
+                                  {exercise.type === "seconds" ? "Seconds" : "Reps"}
+                                </th>
+                                <th scope="col">RPE</th>
+                                <th scope="col">Done</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {exercise.sets.map((set) => (
+                                <tr key={`${exerciseKey}-${set.set}`}>
+                                  <td>{set.set}</td>
+                                  <td>{set.weight || "—"}</td>
+                                  <td>{set.repsOrSec || "—"}</td>
+                                  <td>{set.rpe || "—"}</td>
+                                  <td>{Boolean(set.done) ? "✅" : "—"}</td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                        <div className="exercise-summary-footer">
+                          {exerciseCompleted}/{exercise.sets.length} sets complete
+                        </div>
+                      </div>
+                    );
+                  })}
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -1,0 +1,147 @@
+import Link from "next/link";
+import { ObjectId, type Filter } from "mongodb";
+
+import { getDb } from "@/lib/mongodb";
+import { dedupeWeeksByStart, serializeWeek, type WeekDocument } from "@/lib/week";
+
+import { ArchiveViewer } from "./archive-viewer";
+import type { WeekListEntry } from "./types";
+
+export const dynamic = "force-dynamic";
+
+function buildUserFilter(userId?: string | null): Filter<WeekDocument> {
+  if (!userId) {
+    return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+  }
+
+  const trimmed = userId.trim();
+
+  if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+    return { $or: [{ userId: { $exists: false } }, { userId: null }] };
+  }
+
+  if (!ObjectId.isValid(trimmed)) {
+    throw new Error("Invalid user id");
+  }
+
+  return { userId: new ObjectId(trimmed) };
+}
+
+async function fetchWeeks(userId?: string | null): Promise<WeekListEntry[]> {
+  const db = await getDb();
+  const collection = db.collection<WeekDocument>("weeks");
+  const documents = await collection
+    .find(buildUserFilter(userId), { sort: { createdAt: -1 } })
+    .toArray();
+
+  const mapped = documents.map((doc) => {
+    const serialized = serializeWeek(doc);
+    return {
+      ...serialized,
+      status: doc.status,
+      archivedAt: doc.archivedAt ? doc.archivedAt.toISOString() : null
+    };
+  });
+
+  return dedupeWeeksByStart(mapped);
+}
+
+type WorkoutsPageProps = {
+  searchParams?: {
+    userId?: string;
+  };
+};
+
+export default async function WorkoutsPage({ searchParams }: WorkoutsPageProps) {
+  const requestedUserId = searchParams?.userId ?? null;
+  const normalizedUserId = requestedUserId
+    ? (() => {
+        const trimmed = requestedUserId.trim();
+        if (!trimmed || trimmed === "null" || trimmed === "undefined") {
+          return null;
+        }
+        return trimmed;
+      })()
+    : null;
+  let weeks: WeekListEntry[] = [];
+  let loadError: string | null = null;
+
+  try {
+    weeks = await fetchWeeks(normalizedUserId);
+  } catch (error) {
+    console.error("Failed to load saved workouts", error);
+    if (error instanceof Error && error.message === "Invalid user id") {
+      loadError = "We couldn’t load your saved workouts. Please sign in and try again.";
+    } else {
+      loadError = "We couldn’t load your saved workouts. Check your database connection and try again.";
+    }
+  }
+
+  const ownerIdForLinks =
+    loadError === null ? weeks[0]?.userId ?? normalizedUserId ?? null : null;
+  const progressHref = ownerIdForLinks
+    ? `/progress?userId=${encodeURIComponent(ownerIdForLinks)}`
+    : "/progress";
+
+  return (
+    <div className="archive-page">
+      <div className="wrap archive-wrap">
+        <header className="hero hero-compact archive-hero">
+          <div className="hero-heading archive-hero__heading">
+            <p className="eyebrow">Fitmotion Archive</p>
+            <h1>Saved Workouts</h1>
+            <p className="hero-sub">
+              Browse the weeks you’ve logged, keep tabs on progress, and share highlights anytime.
+            </p>
+          </div>
+          <div className="hero-actions">
+            <Link className="btn ghost" href="/">
+              ← Back to tracker
+            </Link>
+            <Link className="btn ghost" href={progressHref}>
+              <span>Progress insights</span>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3.5 13.5 7.75 9.25 11 12.5 16.5 7"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.8"
+                />
+                <path
+                  d="M16.5 11V7h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.8"
+                />
+              </svg>
+            </Link>
+          </div>
+        </header>
+
+        {loadError ? (
+          <div className="banner error">
+            <span>{loadError}</span>
+          </div>
+        ) : weeks.length === 0 ? (
+          <div className="card">
+            <h2>No workouts saved yet</h2>
+            <p className="muted">
+              Once you log sets on the tracker, they’ll appear here so you can review or export past weeks.
+            </p>
+          </div>
+        ) : (
+          <ArchiveViewer weeks={weeks} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/workouts/types.ts
+++ b/app/workouts/types.ts
@@ -1,0 +1,6 @@
+import type { WeekResponse } from "@/lib/week";
+
+export type WeekListEntry = WeekResponse & {
+  status: "active" | "archived";
+  archivedAt: string | null;
+};

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,40 @@
+import { pbkdf2Sync, randomBytes, timingSafeEqual } from "crypto";
+
+const HASH_ALGORITHM = "sha256";
+const HASH_DELIMITER = "$";
+const HASH_ITERATIONS = 310_000;
+const HASH_KEY_LENGTH = 64; // bytes
+
+export function hashPassword(password: string) {
+  const salt = randomBytes(16).toString("hex");
+  const derived = pbkdf2Sync(password, salt, HASH_ITERATIONS, HASH_KEY_LENGTH, HASH_ALGORITHM).toString("hex");
+  return [HASH_ALGORITHM, HASH_ITERATIONS, salt, derived].join(HASH_DELIMITER);
+}
+
+export function verifyPassword(password: string, stored: string) {
+  const parts = stored.split(HASH_DELIMITER);
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  const [algorithm, iterationValue, salt, storedKey] = parts;
+
+  if (algorithm !== HASH_ALGORITHM) {
+    return false;
+  }
+
+  const iterations = Number.parseInt(iterationValue, 10);
+  if (!Number.isFinite(iterations) || iterations <= 0) {
+    return false;
+  }
+
+  const derived = pbkdf2Sync(password, salt, iterations, storedKey.length / 2, algorithm).toString("hex");
+  const storedBuffer = Buffer.from(storedKey, "hex");
+  const derivedBuffer = Buffer.from(derived, "hex");
+
+  if (storedBuffer.length !== derivedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(storedBuffer, derivedBuffer);
+}

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -4,6 +4,7 @@ export type TemplateExercise = {
   how: string;
   type: "reps" | "seconds";
   sets: number;
+  suggestedWeight: string;
 };
 
 export type TemplateDay = {
@@ -37,35 +38,40 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "8–12 reps",
             how: "Feet shoulder-width; lower until knees ~90°; push through mid-foot.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "140"
           },
           {
             name: "Chest-Supported Row",
             sets: 2,
             target: "8–12 reps",
             how: "Chest on pad/bench; pull to lower ribs; squeeze shoulder blades.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "65"
           },
           {
             name: "Machine Chest Press",
             sets: 2,
             target: "8–12 reps",
             how: "Handles mid-chest; press smoothly; control the return.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "70"
           },
           {
             name: "Seated Leg Curl",
             sets: 2,
             target: "10–15 reps",
             how: "Pad above heels; curl steadily; brief pause; slow back.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "80"
           },
           {
             name: "Pallof Press (Cable)",
             sets: 2,
             target: "20–30 sec/side",
             how: "Cable chest-height; stand side-on; press arms out; resist twist.",
-            type: "seconds"
+            type: "seconds",
+            suggestedWeight: "20"
           }
         ]
       },
@@ -79,35 +85,40 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "8–12 reps",
             how: "Slight lean; pull bar to upper chest; elbows down; control up.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "85"
           },
           {
             name: "Goblet Squat",
             sets: 2,
             target: "8–12 reps",
             how: "Hold weight at chest; sit between hips; stand tall.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "40"
           },
           {
             name: "Seated Cable Row",
             sets: 2,
             target: "8–12 reps",
             how: "Neutral spine; pull to navel/low ribs; squeeze blades.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "75"
           },
           {
             name: "Romanian Deadlift",
             sets: 2,
             target: "8–12 reps",
             how: "Soft knees; push hips back; flat back; stand tall.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "95"
           },
           {
             name: "Calf Raise (Seated/Standing)",
             sets: 2,
             target: "12–15 reps",
             how: "Full heel drop; rise to toes; 1–2s pause.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "70"
           }
         ]
       },
@@ -121,35 +132,40 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "8–12 reps",
             how: "Press without shrugging; smooth down. (Lateral raise: to shoulder height.)",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "35"
           },
           {
             name: "Leg Extension",
             sets: 2,
             target: "10–15 reps",
             how: "Pad on lower shin; extend smoothly; control down.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "55"
           },
           {
             name: "Incline Dumbbell Press",
             sets: 2,
             target: "8–12 reps",
             how: "Bench 15–30°; elbows ~45°; press together; control.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "45"
           },
           {
             name: "Back Extension",
             sets: 2,
             target: "10–12 reps",
             how: "Hinge at hips; neutral spine; squeeze glutes to rise.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "25"
           },
           {
             name: "Farmer Carry",
             sets: 2,
             target: "30–40 sec",
             how: "Stand tall; ribs down; walk steadily without swaying.",
-            type: "seconds"
+            type: "seconds",
+            suggestedWeight: "60"
           }
         ]
       }
@@ -171,28 +187,32 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "8–10 reps",
             how: "Feet shoulder-width; keep heels heavy; control depth.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "200"
           },
           {
             name: "Single-Leg Romanian Deadlift (DB)",
             sets: 2,
             target: "8–10 reps/side",
             how: "Soft knee; hinge from hips; keep hips square; stand tall.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "40"
           },
           {
             name: "Leg Press Calf Raise",
             sets: 2,
             target: "12–15 reps",
             how: "Slow lower; squeeze at top; maintain control.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "140"
           },
           {
             name: "Cable Chop",
             sets: 2,
             target: "20–25 sec/side",
             how: "Arms extended; rotate through torso; resist wobble.",
-            type: "seconds"
+            type: "seconds",
+            suggestedWeight: "25"
           }
         ]
       },
@@ -206,35 +226,40 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "8–12 reps",
             how: "Feet planted; press evenly; pause briefly near chest.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "55"
           },
           {
             name: "Half-Kneeling Single-Arm Pulldown",
             sets: 2,
             target: "8–12 reps/side",
             how: "Kneel tall; pull elbow to hip; keep ribs stacked.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "45"
           },
           {
             name: "Machine Pec Fly or Cable Crossover",
             sets: 2,
             target: "10–15 reps",
             how: "Slight elbow bend; hug motion; slow return.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "70"
           },
           {
             name: "Prone Rear Delt Raise",
             sets: 2,
             target: "12–15 reps",
             how: "Thumbs down; lift to shoulder height; squeeze shoulder blades.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "20"
           },
           {
             name: "Dead Bug",
             sets: 2,
             target: "30–40 sec",
             how: "Lower opposite arm/leg; ribs down; breathe steadily.",
-            type: "seconds"
+            type: "seconds",
+            suggestedWeight: "Bodyweight"
           }
         ]
       },
@@ -248,35 +273,189 @@ export const WEEK_TEMPLATES: WeekTemplate[] = [
             sets: 2,
             target: "6–8 reps",
             how: "Hips back; chest proud; push floor away.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "185"
           },
           {
             name: "Split Squat (Dumbbells)",
             sets: 2,
             target: "8–10 reps/side",
             how: "Front knee over mid-foot; drop back knee straight down; drive through front heel.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "35"
           },
           {
             name: "Chest-Supported Dumbbell Row",
             sets: 2,
             target: "10–12 reps",
             how: "Squeeze shoulder blades; control lowering.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "60"
           },
           {
             name: "Seated Shoulder Press (Dumbbells)",
             sets: 2,
             target: "8–12 reps",
             how: "Brace core; press without arching low back.",
-            type: "reps"
+            type: "reps",
+            suggestedWeight: "45"
           },
           {
             name: "Bike or Rower Steady Effort",
             sets: 2,
             target: "90 sec",
             how: "Moderate pace; breathe rhythmically; stay smooth.",
-            type: "seconds"
+            type: "seconds",
+            suggestedWeight: "Moderate pace"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key: "apex",
+    title: "Apex Strength & Conditioning",
+    description:
+      "High-threshold push, pull, and legs rotation with power primers and core finishers. Built for experienced lifters who enjoy heavier work.",
+    days: [
+      {
+        id: "day1",
+        shortName: "Day 1",
+        name: "Day 1 — Squat + Press Power",
+        exercises: [
+          {
+            name: "Back Squat (Barbell)",
+            sets: 3,
+            target: "5–8 reps",
+            how: "Brace hard, drive knees out, and stand with intent on each rep.",
+            type: "reps",
+            suggestedWeight: "225"
+          },
+          {
+            name: "Paused Bench Press",
+            sets: 3,
+            target: "4–6 reps",
+            how: "One-second pause on the chest; press up while keeping shoulders packed.",
+            type: "reps",
+            suggestedWeight: "185"
+          },
+          {
+            name: "Weighted Pull-Up or Heavy Lat Pulldown",
+            sets: 3,
+            target: "6–8 reps",
+            how: "Pull elbows to your ribs, squeeze, and control the descent.",
+            type: "reps",
+            suggestedWeight: "45"
+          },
+          {
+            name: "Dumbbell Bulgarian Split Squat",
+            sets: 3,
+            target: "8–10 reps/side",
+            how: "Torso tall; drop the back knee straight down; drive through the front heel.",
+            type: "reps",
+            suggestedWeight: "50"
+          },
+          {
+            name: "Cable Face Pull",
+            sets: 3,
+            target: "12–15 reps",
+            how: "Elbows high, pull toward your brow, and pause the squeeze.",
+            type: "reps",
+            suggestedWeight: "35"
+          }
+        ]
+      },
+      {
+        id: "day2",
+        shortName: "Day 2",
+        name: "Day 2 — Pull + Posterior Chain",
+        exercises: [
+          {
+            name: "Trap Bar Deadlift (Heavy)",
+            sets: 3,
+            target: "4–6 reps",
+            how: "Hips down, brace, and push the floor away; finish tall with glutes.",
+            type: "reps",
+            suggestedWeight: "275"
+          },
+          {
+            name: "Standing Military Press",
+            sets: 3,
+            target: "5–8 reps",
+            how: "Glutes tight, ribs stacked, press overhead without leaning back.",
+            type: "reps",
+            suggestedWeight: "95"
+          },
+          {
+            name: "Pendlay Row",
+            sets: 3,
+            target: "6–8 reps",
+            how: "Reset each rep on the floor; pull explosively to your sternum.",
+            type: "reps",
+            suggestedWeight: "155"
+          },
+          {
+            name: "Walking Lunge (Dumbbells)",
+            sets: 3,
+            target: "10–12 steps/side",
+            how: "Short pause between steps, stay tall, and push through the front foot.",
+            type: "reps",
+            suggestedWeight: "50"
+          },
+          {
+            name: "Decline Sit-Up or Cable Crunch",
+            sets: 3,
+            target: "12–15 reps",
+            how: "Brace abs, pull ribs toward hips, and control the return.",
+            type: "reps",
+            suggestedWeight: "25"
+          }
+        ]
+      },
+      {
+        id: "day3",
+        shortName: "Day 3",
+        name: "Day 3 — Push/Pull Finisher + Conditioning",
+        exercises: [
+          {
+            name: "Front Squat or Leg Press Power Set",
+            sets: 3,
+            target: "6–8 reps",
+            how: "Elbows tall, drop under control, and drive up without collapsing.",
+            type: "reps",
+            suggestedWeight: "205"
+          },
+          {
+            name: "Incline Dumbbell Press (Heavy)",
+            sets: 3,
+            target: "6–8 reps",
+            how: "Bench ~30°; lower slow; press together with a strong lockout.",
+            type: "reps",
+            suggestedWeight: "70"
+          },
+          {
+            name: "Chest-Supported T-Bar Row",
+            sets: 3,
+            target: "8–10 reps",
+            how: "Neutral grip; pull toward low chest; squeeze shoulder blades.",
+            type: "reps",
+            suggestedWeight: "90"
+          },
+          {
+            name: "Romanian Deadlift (Barbell or Dumbbell)",
+            sets: 3,
+            target: "8–10 reps",
+            how: "Soft knees, hinge at the hips, feel hamstrings, and snap tall.",
+            type: "reps",
+            suggestedWeight: "185"
+          },
+          {
+            name: "SkiErg or Bike Sprint Intervals",
+            sets: 3,
+            target: "45 sec steady + 15 sec push",
+            how: "Alternate 45s smooth effort with a 15s surge; focus on crisp breathing.",
+            type: "seconds",
+            suggestedWeight: "Damper 6"
           }
         ]
       }

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -1,0 +1,57 @@
+import type { Collection, WithId } from "mongodb";
+
+import { getDb } from "./mongodb";
+
+export type UserDocument = {
+  name: string;
+  email: string;
+  passwordHash: string;
+  createdAt: Date;
+  updatedAt: Date;
+  lastLoginAt?: Date;
+};
+
+export type UserResponse = {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt: string | null;
+};
+
+let usersCollectionPromise: Promise<Collection<UserDocument>> | null = null;
+
+export function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export async function getUsersCollection(): Promise<Collection<UserDocument>> {
+  if (!usersCollectionPromise) {
+    usersCollectionPromise = (async () => {
+      const db = await getDb();
+      const collection = db.collection<UserDocument>("users");
+      await collection.createIndex({ email: 1 }, { unique: true });
+      return collection;
+    })();
+  }
+
+  return usersCollectionPromise;
+}
+
+export async function findUserByEmail(email: string) {
+  const normalized = normalizeEmail(email);
+  const collection = await getUsersCollection();
+  return collection.findOne({ email: normalized });
+}
+
+export function serializeUser(doc: WithId<UserDocument>): UserResponse {
+  return {
+    id: doc._id.toString(),
+    name: doc.name,
+    email: doc.email,
+    createdAt: doc.createdAt.toISOString(),
+    updatedAt: doc.updatedAt.toISOString(),
+    lastLoginAt: doc.lastLoginAt ? doc.lastLoginAt.toISOString() : null
+  };
+}

--- a/lib/week.ts
+++ b/lib/week.ts
@@ -1,4 +1,4 @@
-import type { WithId } from "mongodb";
+import type { ObjectId, WithId } from "mongodb";
 import { getTemplate, WEEK_TEMPLATES } from "./templates";
 import type { WeekTemplate } from "./templates";
 
@@ -15,6 +15,7 @@ export type ExerciseEntry = {
   target: string;
   how: string;
   type: "reps" | "seconds";
+  suggestedWeight?: string;
   sets: SetEntry[];
 };
 
@@ -35,6 +36,7 @@ export type WeekDocument = {
   createdAt: Date;
   updatedAt: Date;
   archivedAt?: Date;
+  userId?: ObjectId | null;
   days: DayEntry[];
 };
 
@@ -47,31 +49,142 @@ export type WeekResponse = {
   description: string;
   createdAt: string;
   updatedAt: string;
+  userId: string | null;
   days: DayEntry[];
 };
 
-export function getMonday(date = new Date()): string {
-  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+export function getWeekStart(dateInput: Date = new Date()): string {
+  const date = Number.isNaN(dateInput.getTime()) ? new Date() : dateInput;
+
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   const day = d.getUTCDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  d.setUTCDate(d.getUTCDate() + diff);
+  d.setUTCDate(d.getUTCDate() - day);
   d.setUTCHours(0, 0, 0, 0);
   return d.toISOString().substring(0, 10);
 }
 
-function buildSets(count: number): SetEntry[] {
+export function getNextWeekStart(weekOf: string): string {
+  const base = new Date(`${weekOf}T00:00:00.000Z`);
+
+  if (Number.isNaN(base.getTime())) {
+    return getWeekStart();
+  }
+
+  const normalized = new Date(`${getWeekStart(base)}T00:00:00.000Z`);
+  normalized.setUTCDate(normalized.getUTCDate() + 7);
+  return normalized.toISOString().substring(0, 10);
+}
+
+type WeekLike = {
+  weekOf: string;
+  updatedAt: string;
+  createdAt?: string;
+  status?: "active" | "archived";
+};
+
+function parseDate(value: string | undefined): number {
+  if (!value) return Number.NaN;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? Number.NaN : timestamp;
+}
+
+export function dedupeWeeksByStart<T extends WeekLike>(weeks: T[]): T[] {
+  const groups = new Map<string, T[]>();
+
+  for (const week of weeks) {
+    const existing = groups.get(week.weekOf);
+    if (existing) {
+      existing.push(week);
+    } else {
+      groups.set(week.weekOf, [week]);
+    }
+  }
+
+  const deduped: T[] = [];
+
+  for (const entries of Array.from(groups.values())) {
+    const winner = entries.reduce<T | null>((best, candidate) => {
+      if (!best) {
+        return candidate;
+      }
+
+      const bestStatus = best.status;
+      const candidateStatus = candidate.status;
+
+      if (bestStatus !== "archived" && candidateStatus === "archived") {
+        return candidate;
+      }
+
+      if (bestStatus === "archived" && candidateStatus !== "archived") {
+        return best;
+      }
+
+      const bestUpdated = parseDate(best.updatedAt);
+      const candidateUpdated = parseDate(candidate.updatedAt);
+
+      if (!Number.isNaN(candidateUpdated) && !Number.isNaN(bestUpdated)) {
+        if (candidateUpdated > bestUpdated) {
+          return candidate;
+        }
+        if (candidateUpdated < bestUpdated) {
+          return best;
+        }
+      }
+
+      const bestCreated = parseDate(best.createdAt);
+      const candidateCreated = parseDate(candidate.createdAt);
+
+      if (!Number.isNaN(candidateCreated) && !Number.isNaN(bestCreated)) {
+        if (candidateCreated > bestCreated) {
+          return candidate;
+        }
+        if (candidateCreated < bestCreated) {
+          return best;
+        }
+      }
+
+      return candidate;
+    }, null);
+
+    if (winner) {
+      deduped.push(winner);
+    }
+  }
+
+  deduped.sort((a, b) => {
+    const updatedDiff = parseDate(b.updatedAt) - parseDate(a.updatedAt);
+    if (!Number.isNaN(updatedDiff) && updatedDiff !== 0) {
+      return updatedDiff;
+    }
+
+    const createdDiff = parseDate(b.createdAt ?? b.updatedAt) - parseDate(a.createdAt ?? a.updatedAt);
+    if (!Number.isNaN(createdDiff) && createdDiff !== 0) {
+      return createdDiff;
+    }
+
+    return b.weekOf.localeCompare(a.weekOf);
+  });
+
+  return deduped;
+}
+
+function buildSets(count: number, suggestedWeight?: string): SetEntry[] {
   return Array.from({ length: count }).map((_, index) => ({
     set: index + 1,
-    weight: "",
+    weight: suggestedWeight ?? "",
     repsOrSec: "",
     rpe: "",
     done: false
   }));
 }
 
-export function createWeekDocument(templateIndex: number, weekOf?: string): WeekDocument {
+export function createWeekDocument(
+  templateIndex: number,
+  weekOf?: string,
+  userId?: ObjectId | null
+): WeekDocument {
   const template: WeekTemplate = getTemplate(templateIndex);
-  const resolvedWeekOf = weekOf ?? getMonday();
+  const resolvedWeekOf = weekOf ?? getWeekStart();
   const now = new Date();
 
   const days: DayEntry[] = template.days.map((day) => ({
@@ -83,11 +196,12 @@ export function createWeekDocument(templateIndex: number, weekOf?: string): Week
       target: exercise.target,
       how: exercise.how,
       type: exercise.type,
-      sets: buildSets(exercise.sets)
+      suggestedWeight: exercise.suggestedWeight,
+      sets: buildSets(exercise.sets, exercise.suggestedWeight)
     }))
   }));
 
-  return {
+  const doc: WeekDocument = {
     weekOf: resolvedWeekOf,
     templateKey: template.key,
     templateTitle: template.title,
@@ -98,9 +212,43 @@ export function createWeekDocument(templateIndex: number, weekOf?: string): Week
     updatedAt: now,
     days
   };
+
+  if (userId) {
+    doc.userId = userId;
+  }
+
+  return doc;
 }
 
 export function serializeWeek(doc: WithId<WeekDocument>): WeekResponse {
+  const template = getTemplate(doc.templateIndex);
+
+  function resolveTemplateDay(dayId: string, dayName: string) {
+    const prefix = `${doc.templateKey}-`;
+    const bareId = dayId.startsWith(prefix) ? dayId.slice(prefix.length) : dayId;
+    return (
+      template.days.find((candidate) => candidate.id === bareId) ||
+      template.days.find((candidate) => candidate.name === dayName)
+    );
+  }
+
+  function selectSuggestedWeight(
+    dayId: string,
+    dayName: string,
+    exercise: WeekDocument["days"][number]["exercises"][number]
+  ) {
+    if (exercise.suggestedWeight && exercise.suggestedWeight.trim().length > 0) {
+      return exercise.suggestedWeight.trim();
+    }
+
+    const templateDay = resolveTemplateDay(dayId, dayName);
+    const templateExercise = templateDay?.exercises.find(
+      (candidate) => candidate.name === exercise.name
+    );
+
+    return templateExercise?.suggestedWeight?.trim() ?? "";
+  }
+
   return {
     id: doc._id.toString(),
     weekOf: doc.weekOf,
@@ -110,23 +258,38 @@ export function serializeWeek(doc: WithId<WeekDocument>): WeekResponse {
     description: doc.description,
     createdAt: doc.createdAt.toISOString(),
     updatedAt: doc.updatedAt.toISOString(),
+    userId: doc.userId ? doc.userId.toString() : null,
     days: doc.days.map((day) => ({
       id: day.id,
       shortName: day.shortName,
       name: day.name,
-      exercises: day.exercises.map((exercise) => ({
-        name: exercise.name,
-        target: exercise.target,
-        how: exercise.how,
-        type: exercise.type,
-        sets: exercise.sets.map((set) => ({
-          set: set.set,
-          weight: set.weight,
-          repsOrSec: set.repsOrSec,
-          rpe: set.rpe,
-          done: set.done
-        }))
-      }))
+      exercises: day.exercises.map((exercise) => {
+        const suggestedWeight = selectSuggestedWeight(day.id, day.name, exercise);
+        const normalizedSuggestion = suggestedWeight.trim();
+        const resolvedSuggestion = normalizedSuggestion.length > 0 ? normalizedSuggestion : undefined;
+
+        return {
+          name: exercise.name,
+          target: exercise.target,
+          how: exercise.how,
+          type: exercise.type,
+          suggestedWeight: resolvedSuggestion,
+          sets: exercise.sets.map((set) => {
+            const hasWeight = typeof set.weight === "string" && set.weight.trim().length > 0;
+            const resolvedWeight = hasWeight
+              ? set.weight
+              : resolvedSuggestion ?? "";
+
+            return {
+              set: set.set,
+              weight: resolvedWeight,
+              repsOrSec: set.repsOrSec,
+              rpe: set.rpe,
+              done: Boolean(set.done)
+            };
+          })
+        };
+      })
     }))
   };
 }

--- a/public/fitmotion-logo.svg
+++ b/public/fitmotion-logo.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="fitmotion-mark-title">
+  <title id="fitmotion-mark-title">Fitmotion mark</title>
+  <defs>
+    <clipPath id="fitmotion-circle">
+      <circle cx="128" cy="128" r="108" />
+    </clipPath>
+    <mask id="fitmotion-swipe">
+      <rect width="256" height="256" fill="#fff" />
+      <circle cx="110" cy="150" r="88" fill="#000" />
+    </mask>
+  </defs>
+  <circle cx="128" cy="128" r="108" fill="#0f1115" />
+  <g clip-path="url(#fitmotion-circle)">
+    <circle cx="158" cy="92" r="96" fill="#10b7b0" mask="url(#fitmotion-swipe)" />
+  </g>
+</svg>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,12 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -35,7 +40,8 @@
     "**/*.js",
     "**/*.jsx",
     "**/*.cjs",
-    "**/*.mjs"
+    "**/*.mjs",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- compute a dayCount when tallying saved-week sets so logged days only include workouts with completed sets
- surface the new dayCount in the saved-workouts summary instead of counting every scheduled day

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ec15a1e48327a87f762caf849e38